### PR TITLE
[FEAT] SMS 인증을 통한 ID/PW 찾기 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // SMS
+	implementation 'net.nurigo:sdk:4.3.0'
+
 	// DB
 	runtimeOnly 'org.postgresql:postgresql'
 

--- a/src/main/java/com/mumuk/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/AuthController.java
@@ -62,10 +62,24 @@ public class AuthController {
     }
 
     @Operation(summary = "Id 찾기", description = "이름과 휴대폰 번호 입력하여 SMS 메시지를 통해 아이디의 일부를 찾습니다.")
-    @PatchMapping("/recover-id")
+    @PatchMapping("/find-id")
     public Response<String> findId(@Valid @RequestBody AuthRequest.FindIdReq request) {
         authService.findUserIdAndSendSms(request);
         return Response.ok(ResultCode.SEND_ID_BY_SMS_OK, "SMS 메시지로 ID의 일부를 확인하실 수 있습니다.");
     }
 
+    @Operation(summary = "비밀번호 찾기", description = "id와 이름, 휴대폰 번호를 입력하여 SMS 메시지로 초기화 비밀번호를 발급 받습니다.")
+    @PatchMapping("/find-pw")
+    public Response<String> findPassWord(@Valid @RequestBody AuthRequest.FindPassWordReq request) {
+        authService.findUserPassWordAndSendSms(request);
+        return Response.ok(ResultCode.SEND_PW_BY_SMS_OK, "SMS 메시지로 PW의 일부를 확인하실 수 있습니다.");
+    }
+
+    @Operation(summary = "비밀번호 재설성", description = "비밀번호를 재설정합니다.")
+    @PatchMapping("/reissue-pw")
+    public Response<String> reissuePassWord(@Valid @RequestBody AuthRequest.RecoverPassWordReq req, HttpServletRequest request ) {
+        String accessToken = request.getHeader("Authorization");
+        authService.reissueUserPassword(req, accessToken);
+        return Response.ok(ResultCode.PW_REISSUE_OK, "성공적으로 비밀번호가 변경되었습니다.");
+    }
 }

--- a/src/main/java/com/mumuk/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/AuthController.java
@@ -39,7 +39,7 @@ public class AuthController {
         return Response.ok(ResultCode.USER_LOGIN_OK, tokenResponse);
     }
 
-    @Operation(summary = "로그아웃", description = "Access Token 을 통해 검증 후 로그아웃")
+    @Operation(summary = "로그아웃", description = "Access Token 을 통해 검증 후 로그아웃이 진행됩니다.")
     @PatchMapping("/logout")
     public Response<String> logout(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization");
@@ -47,7 +47,7 @@ public class AuthController {
         return Response.ok(ResultCode.USER_LOGOUT_OK, "로그아웃이 완료되었습니다.");
     }
 
-    @Operation(summary = "회원 탈퇴", description = "Access Token 을 통해 검증 후 회원 탈퇴")
+    @Operation(summary = "회원 탈퇴", description = "Access Token 을 통해 검증 후 회원 탈퇴가 진행됩니다.")
     @DeleteMapping("/withdraw")
     public Response<String> withdraw(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization");
@@ -61,5 +61,12 @@ public class AuthController {
         TokenResponse tokenResponse = authService.reissue(refreshToken);
         return Response.ok(ResultCode.TOKEN_REISSUE_OK, tokenResponse);
     }
+
+//    @Operation(summary = "Id 찾기", description = "")
+//    @PatchMapping("/id")
+//    public Response<TokenResponse> findId(@RequestHeader("X-Refresh-Token") String refreshToken) {
+//        TokenResponse tokenResponse = authService.findId(refreshToken);
+//        return Response.ok(ResultCode.TOKEN_REISSUE_OK, tokenResponse);
+//    }
 
 }

--- a/src/main/java/com/mumuk/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/AuthController.java
@@ -39,15 +39,14 @@ public class AuthController {
         return Response.ok(ResultCode.USER_LOGIN_OK, tokenResponse);
     }
 
-    @Operation(summary = "로그아웃", description = "Access Token 을 통해 검증 후 로그아웃이 진행됩니다.")
+    @Operation(summary = "로그아웃", description = "Refresh Token 을 통해 검증 후 로그아웃이 진행됩니다.")
     @PatchMapping("/logout")
-    public Response<String> logout(HttpServletRequest request) {
-        String accessToken = request.getHeader("Authorization");
-        authService.logout(accessToken);
+    public Response<String> logout(@RequestHeader("X-Refresh-Token") String refreshToken) {
+        authService.logout(refreshToken);
         return Response.ok(ResultCode.USER_LOGOUT_OK, "로그아웃이 완료되었습니다.");
     }
 
-    @Operation(summary = "회원 탈퇴", description = "Access Token 을 통해 검증 후 회원 탈퇴가 진행됩니다.")
+    @Operation(summary = "회원 탈퇴", description = "Access Token 을 통해 사용자 인증을 검증 후 회원 탈퇴가 진행됩니다.")
     @DeleteMapping("/withdraw")
     public Response<String> withdraw(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization");

--- a/src/main/java/com/mumuk/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.mumuk.domain.user.dto.response.TokenResponse;
 import com.mumuk.domain.user.service.AuthService;
 import com.mumuk.global.apiPayload.code.ResultCode;
 import com.mumuk.global.apiPayload.response.Response;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -24,18 +25,21 @@ public class AuthController {
     }
 
 
+    @Operation(summary = "회원 가입")
     @PostMapping("/sign-up")
     public Response<String> signUp(@Valid @RequestBody AuthRequest.SignUpReq request) {
         authService.signUp(request);
         return Response.ok(ResultCode.USER_SIGNUP_OK, "회원 가입이 완료되었습니다.");
     }
 
+    @Operation(summary = "로그인", description = "이메일과 비밀번호 입력을 통해 로그인 후, Access Token 과 Refresh Token 이 반환됩니다.")
     @PostMapping("/login")
     public Response<TokenResponse> login(@Valid @RequestBody AuthRequest.LogInReq request, HttpServletResponse response) {
         TokenResponse tokenResponse = authService.logIn(request, response);
         return Response.ok(ResultCode.USER_LOGIN_OK, tokenResponse);
     }
 
+    @Operation(summary = "로그아웃", description = "Access Token 을 통해 검증 후 로그아웃")
     @PatchMapping("/logout")
     public Response<String> logout(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization");
@@ -43,6 +47,7 @@ public class AuthController {
         return Response.ok(ResultCode.USER_LOGOUT_OK, "로그아웃이 완료되었습니다.");
     }
 
+    @Operation(summary = "회원 탈퇴", description = "Access Token 을 통해 검증 후 회원 탈퇴")
     @DeleteMapping("/withdraw")
     public Response<String> withdraw(HttpServletRequest request) {
         String accessToken = request.getHeader("Authorization");
@@ -50,5 +55,11 @@ public class AuthController {
         return Response.ok(ResultCode.USER_WITHDRAW_OK, "회원 탈퇴가 완료되었습니다.");
     }
 
+    @Operation(summary = "토큰 재발급", description = "Refresh Token 을 통해 새로운 Access Token 과 Refresh Token 을 발급합니다.")
+    @PostMapping("/reissue")
+    public Response<TokenResponse> reissue(@RequestHeader("X-Refresh-Token") String refreshToken) {
+        TokenResponse tokenResponse = authService.reissue(refreshToken);
+        return Response.ok(ResultCode.TOKEN_REISSUE_OK, tokenResponse);
+    }
 
 }

--- a/src/main/java/com/mumuk/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/AuthController.java
@@ -61,11 +61,11 @@ public class AuthController {
         return Response.ok(ResultCode.TOKEN_REISSUE_OK, tokenResponse);
     }
 
-//    @Operation(summary = "Id 찾기", description = "")
-//    @PatchMapping("/id")
-//    public Response<TokenResponse> findId(@RequestHeader("X-Refresh-Token") String refreshToken) {
-//        TokenResponse tokenResponse = authService.findId(refreshToken);
-//        return Response.ok(ResultCode.TOKEN_REISSUE_OK, tokenResponse);
-//    }
+    @Operation(summary = "Id 찾기", description = "이름과 휴대폰 번호 입력하여 SMS 메시지를 통해 아이디의 일부를 찾습니다.")
+    @PatchMapping("/recover-id")
+    public Response<String> findId(@Valid @RequestBody AuthRequest.FindIdReq request) {
+        authService.findUserIdAndSendSms(request);
+        return Response.ok(ResultCode.SEND_ID_BY_SMS_OK, "SMS 메시지로 ID의 일부를 확인하실 수 있습니다.");
+    }
 
 }

--- a/src/main/java/com/mumuk/domain/user/converter/TokenResponseConverter.java
+++ b/src/main/java/com/mumuk/domain/user/converter/TokenResponseConverter.java
@@ -1,0 +1,13 @@
+package com.mumuk.domain.user.converter;
+
+
+import com.mumuk.domain.user.dto.response.TokenResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenResponseConverter {
+
+    public TokenResponse toResponse(String accessToken, String refreshToken) {
+        return new TokenResponse(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/mumuk/domain/user/dto/request/AuthRequest.java
+++ b/src/main/java/com/mumuk/domain/user/dto/request/AuthRequest.java
@@ -50,4 +50,29 @@ public class AuthRequest {
         @NotBlank
         private String phoneNumber;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class FindPassWordReq{
+        @NotBlank
+        private String loginId;
+
+        @NotBlank
+        private String name;
+
+        @NotBlank
+        private String phoneNumber;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class RecoverPassWordReq {
+        @NotBlank
+        private String passWord;
+
+        @NotBlank
+        private String confirmPassword;
+    }
 }

--- a/src/main/java/com/mumuk/domain/user/dto/request/AuthRequest.java
+++ b/src/main/java/com/mumuk/domain/user/dto/request/AuthRequest.java
@@ -73,6 +73,6 @@ public class AuthRequest {
         private String passWord;
 
         @NotBlank
-        private String confirmPassword;
+        private String confirmPassWord;
     }
 }

--- a/src/main/java/com/mumuk/domain/user/dto/request/AuthRequest.java
+++ b/src/main/java/com/mumuk/domain/user/dto/request/AuthRequest.java
@@ -17,10 +17,10 @@ public class AuthRequest {
         private String nickname;
 
         @NotBlank
-        private String loginId;
+        private String phoneNumber;
 
         @NotBlank
-        private String phoneNumber;
+        private String loginId;
 
         @NotBlank
         private String password;
@@ -40,4 +40,14 @@ public class AuthRequest {
         private String password;
     }
 
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class FindIdReq{
+        @NotBlank
+        private String name;
+
+        @NotBlank
+        private String phoneNumber;
+    }
 }

--- a/src/main/java/com/mumuk/domain/user/dto/request/AuthRequest.java
+++ b/src/main/java/com/mumuk/domain/user/dto/request/AuthRequest.java
@@ -17,7 +17,10 @@ public class AuthRequest {
         private String nickname;
 
         @NotBlank
-        private String email;
+        private String loginId;
+
+        @NotBlank
+        private String phoneNumber;
 
         @NotBlank
         private String password;
@@ -31,7 +34,7 @@ public class AuthRequest {
     @NoArgsConstructor
     public static class LogInReq{
         @NotBlank
-        private String email;
+        private String loginId;
 
         @NotBlank
         private String password;

--- a/src/main/java/com/mumuk/domain/user/entity/User.java
+++ b/src/main/java/com/mumuk/domain/user/entity/User.java
@@ -21,7 +21,6 @@ public class User extends BaseEntity {
 
     private String profileImage;
 
-    @Column(nullable = false, unique = true)
     private String email;     // 자체&소셜 Id
 
     private String loginId;   // 자체 로그인 id
@@ -32,7 +31,7 @@ public class User extends BaseEntity {
 
     private String nickname;
 
-    private String phone_number;
+    private String phoneNumber;
 
     private String statusMessage;
 
@@ -41,9 +40,22 @@ public class User extends BaseEntity {
 
     private String refreshToken;
 
-    public User(String name, String nickname, String loginId, String encodedPassword, String phoneNumber) {
+    public User() {
 
     }
+
+    public User(String name, String nickname, String phoneNumber, String loginId, String password) {
+        this.name = name;
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.loginId = loginId;
+        this.password = password;
+    }
+
+    public static User of(String name, String nickname, String loginId, String encodedPassword, String phoneNumber) {
+        return new User(name, nickname, loginId, encodedPassword, phoneNumber);
+    }
+
 
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
@@ -80,10 +92,6 @@ public class User extends BaseEntity {
 
     public String getNickname() {
         return nickname;
-    }
-
-    public String getPhone_number() {
-        return phone_number;
     }
 
     public String getStatusMessage() {
@@ -125,9 +133,6 @@ public class User extends BaseEntity {
 
     public void setNickname(String nickname) {this.nickname = nickname;}
 
-    public void setPhone_number(String phone_number) {
-        this.phone_number = phone_number;
-    }
 
     public void setStatusMessage(String statusMessage) {
         this.statusMessage = statusMessage;
@@ -135,19 +140,6 @@ public class User extends BaseEntity {
 
     public void setSocialId(String socialId) {
         this.socialId = socialId;
-    }
-
-
-    public static User of(String name, String nickname, String loginId, String encodedPassword, String phoneNumber) {
-        return new User(name, nickname, loginId, encodedPassword, phoneNumber);
-    }
-
-    public User(Long id, String name, String nickname, String email, String password) {
-        this.id = id;
-        this.name = name;
-        this.nickname = nickname;
-        this.email = email;
-        this.password = password;
     }
 
     public String getRefreshToken() {
@@ -164,5 +156,13 @@ public class User extends BaseEntity {
 
     public void setLoginId(String loginId) {
         this.loginId = loginId;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public void setPhoneNumber(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
     }
 }

--- a/src/main/java/com/mumuk/domain/user/entity/User.java
+++ b/src/main/java/com/mumuk/domain/user/entity/User.java
@@ -23,6 +23,7 @@ public class User extends BaseEntity {
 
     private String email;     // 자체&소셜 Id
 
+    @Column(unique = true)
     private String loginId;   // 자체 로그인 id
 
     private String password;  // 자체 로그인 pw
@@ -44,12 +45,12 @@ public class User extends BaseEntity {
 
     }
 
-    public User(String name, String nickname, String phoneNumber, String loginId, String password) {
+    public User(String name, String nickname, String loginId, String password, String phoneNumber) {
         this.name = name;
         this.nickname = nickname;
-        this.phoneNumber = phoneNumber;
         this.loginId = loginId;
         this.password = password;
+        this.phoneNumber = phoneNumber;
     }
 
     public static User of(String name, String nickname, String loginId, String encodedPassword, String phoneNumber) {

--- a/src/main/java/com/mumuk/domain/user/entity/User.java
+++ b/src/main/java/com/mumuk/domain/user/entity/User.java
@@ -3,7 +3,6 @@ package com.mumuk.domain.user.entity;
 
 import com.mumuk.global.common.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Builder;
 
 
 @Entity
@@ -25,7 +24,9 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;     // 자체&소셜 Id
 
-    private String password;
+    private String loginId;   // 자체 로그인 id
+
+    private String password;  // 자체 로그인 pw
 
     private String name;
 
@@ -40,7 +41,7 @@ public class User extends BaseEntity {
 
     private String refreshToken;
 
-    public User() {
+    public User(String name, String nickname, String loginId, String encodedPassword, String phoneNumber) {
 
     }
 
@@ -136,8 +137,9 @@ public class User extends BaseEntity {
         this.socialId = socialId;
     }
 
-    public static User of(String name, String nickname, String email, String password) {
-        return new User(null, name, nickname, email, password);
+
+    public static User of(String name, String nickname, String loginId, String encodedPassword, String phoneNumber) {
+        return new User(name, nickname, loginId, encodedPassword, phoneNumber);
     }
 
     public User(Long id, String name, String nickname, String email, String password) {
@@ -154,5 +156,13 @@ public class User extends BaseEntity {
 
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public String getLoginId() {
+        return loginId;
+    }
+
+    public void setLoginId(String loginId) {
+        this.loginId = loginId;
     }
 }

--- a/src/main/java/com/mumuk/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/mumuk/domain/user/repository/UserRepository.java
@@ -12,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByLoginId(String loginId);
     Optional<User> findByPhoneNumber(String phoneNumber);
     Optional<User> findByNameAndPhoneNumber(String name, String phoneNumber);
+    Optional<User> findByLoginIdAndNameAndPhoneNumber(String loginId, String name, String phoneNumber);
 }

--- a/src/main/java/com/mumuk/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/mumuk/domain/user/repository/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByPhoneNumber(String phoneNumber);
     Optional<User> findByLoginId(String loginId);
     Optional<User> findByPhoneNumber(String phoneNumber);
+    Optional<User> findByNameAndPhoneNumber(String name, String phoneNumber);
 }

--- a/src/main/java/com/mumuk/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/mumuk/domain/user/repository/UserRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByEmail(String email);
-    boolean existsByEmail(String email);
+    boolean existsByLoginId(String loginId);
+    boolean existsByPhoneNumber(String phoneNumber);
+    Optional<User> findByLoginId(String loginId);
+    Optional<User> findByPhoneNumber(String phoneNumber);
 }

--- a/src/main/java/com/mumuk/domain/user/service/AuthService.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthService.java
@@ -8,7 +8,7 @@ public interface AuthService {
 
     void signUp(AuthRequest.SignUpReq request);
     TokenResponse logIn(AuthRequest.LogInReq request, HttpServletResponse response);
-    void logout(String accessToken);
+    void logout(String refreshToken);
     void withdraw(String accessToken);
     TokenResponse reissue(String refreshToken);
 }

--- a/src/main/java/com/mumuk/domain/user/service/AuthService.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthService.java
@@ -10,4 +10,5 @@ public interface AuthService {
     TokenResponse logIn(AuthRequest.LogInReq request, HttpServletResponse response);
     void logout(String accessToken);
     void withdraw(String accessToken);
+    TokenResponse reissue(String refreshToken);
 }

--- a/src/main/java/com/mumuk/domain/user/service/AuthService.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthService.java
@@ -11,4 +11,5 @@ public interface AuthService {
     void logout(String refreshToken);
     void withdraw(String accessToken);
     TokenResponse reissue(String refreshToken);
+    void findUserIdAndSendSms(AuthRequest.FindIdReq request);
 }

--- a/src/main/java/com/mumuk/domain/user/service/AuthService.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthService.java
@@ -12,4 +12,6 @@ public interface AuthService {
     void withdraw(String accessToken);
     TokenResponse reissue(String refreshToken);
     void findUserIdAndSendSms(AuthRequest.FindIdReq request);
+    void findUserPassWordAndSendSms(AuthRequest.FindPassWordReq request);
+    void reissueUserPassword(AuthRequest.RecoverPassWordReq request, String accessToken);
 }

--- a/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
@@ -7,6 +7,7 @@ import com.mumuk.domain.user.entity.User;
 import com.mumuk.domain.user.repository.UserRepository;
 import com.mumuk.global.apiPayload.exception.AuthException;
 import com.mumuk.global.security.jwt.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -35,8 +36,12 @@ public class AuthServiceImpl implements AuthService {
 
         validateRequest(request);
 
-        if (userRepository.existsByEmail(request.getEmail())) {
-            throw new AuthException(ErrorCode.EMAIL_ALREADY_EXISTS);
+        if (userRepository.existsByLoginId(request.getLoginId())) {
+            throw new AuthException(ErrorCode.LOGIN_ID_ALREADY_EXISTS);
+        }
+
+        if (userRepository.existsByPhoneNumber(request.getPhoneNumber())) {
+            throw new AuthException(ErrorCode.PHONE_NUMBER_ALREADY_EXISTS);
         }
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
@@ -44,7 +49,8 @@ public class AuthServiceImpl implements AuthService {
         User user = User.of(
                 request.getName(),
                 request.getNickname(),
-                request.getEmail(),
+                request.getLoginId(),
+                request.getPhoneNumber(),
                 encodedPassword
         );
         userRepository.save(user);
@@ -53,15 +59,15 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public TokenResponse logIn(AuthRequest.LogInReq request, HttpServletResponse response) {
 
-        User user = userRepository.findByEmail(request.getEmail())
+        User user = userRepository.findByLoginId(request.getLoginId())
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new AuthException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
         }
 
-        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail());
-        String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
+        String accessToken = jwtTokenProvider.createAccessToken(user.getLoginId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getLoginId());
 
 
         user.updateRefreshToken(refreshToken);
@@ -74,15 +80,11 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Transactional
-    public void logout(String accessToken) {
-        if (accessToken == null || !accessToken.startsWith("Bearer ")) {
+    public void logout(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
             throw new AuthException(ErrorCode.JWT_INVALID_TOKEN);
         }
-
-        String email = jwtTokenProvider.getEmailFromToken(accessToken);
-
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+        User user = getUserFromToken(refreshToken);
 
         user.updateRefreshToken(null);
         userRepository.save(user);
@@ -93,12 +95,7 @@ public class AuthServiceImpl implements AuthService {
         if (accessToken == null || !accessToken.startsWith("Bearer ")) {
             throw new AuthException(ErrorCode.JWT_INVALID_TOKEN);
         }
-
-        String token = accessToken.substring(7).trim();   // "Bearer " 제거
-        String email = jwtTokenProvider.getEmailFromToken(token);
-
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+        User user = getUserFromToken(accessToken);
 
         userRepository.delete(user);
     }
@@ -113,9 +110,8 @@ public class AuthServiceImpl implements AuthService {
             throw new AuthException(ErrorCode.JWT_INVALID_TOKEN);
         }
 
-        String email = jwtTokenProvider.getEmailFromToken(refreshToken);
-
-        User user = userRepository.findByEmail(email)
+        String phoneNumber = jwtTokenProvider.getPhoneNumberFromToken(refreshToken);
+        User user = userRepository.findByLoginId(phoneNumber)
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
 
         // 저장된 refreshToken이 없으면 재발급 불가
@@ -124,8 +120,8 @@ public class AuthServiceImpl implements AuthService {
             throw new AuthException(ErrorCode.JWT_INVALID_TOKEN);
         }
 
-        String newAccessToken = jwtTokenProvider.createAccessToken(email);
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(email);
+        String newAccessToken = jwtTokenProvider.createAccessToken(phoneNumber);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(phoneNumber);
 
         // refreshToken 갱신
         user.updateRefreshToken(newRefreshToken);
@@ -144,22 +140,28 @@ public class AuthServiceImpl implements AuthService {
             throw new AuthException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
         }
 
-        if (!isValidEmail(request.getEmail())) {
-            throw new AuthException(ErrorCode.INVALID_EMAIL_FORMAT);
-        }
-
         if (!isValidPassword(request.getPassword())) {
             throw new AuthException(ErrorCode.INVALID_PASSWORD_FORMAT);
         }
     }
 
-    private boolean isValidNickname(String nickname) {
-        return nickname != null && nickname.length() <= 10;
+    // token -> Claim 객체 -> Subject 을 이용한 사용자 phoneNumber 추출
+    private User getUserFromToken(String token) {
+        Claims claims = jwtTokenProvider.getClaimsFromToken(token);
+
+        String category = claims.get("category", String.class);
+        if (!"access".equals(category) && !"refresh".equals(category)) {
+            throw new AuthException(ErrorCode.JWT_INVALID_TOKEN);
+        }
+
+        String phoneNumber = claims.getSubject();
+
+        return userRepository.findByPhoneNumber(phoneNumber)
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
     }
 
-    private boolean isValidEmail(String email) {
-        String regex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$";
-        return Pattern.matches(regex, email);
+    private boolean isValidNickname(String nickname) {
+        return nickname != null && nickname.length() <= 10;
     }
 
     private boolean isValidPassword(String password) {

--- a/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
@@ -174,7 +174,7 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public void reissueUserPassword(AuthRequest.RecoverPassWordReq request, String accessToken) {
         String newPassword = request.getPassWord();
-        String confirmPassword = request.getConfirmPassword();
+        String confirmPassword = request.getConfirmPassWord();
 
         if (!newPassword.equals(confirmPassword)) {
             throw new AuthException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
@@ -200,7 +200,7 @@ public class AuthServiceImpl implements AuthService {
             throw new AuthException(ErrorCode.INVALID_NICKNAME_FORMAT);
         }
 
-        if(!isValidloginId(request.getLoginId())) {
+        if(!isValidLoginId(request.getLoginId())) {
             throw new AuthException(ErrorCode.INVALID_LOGIN_ID_FORMAT);
         }
 
@@ -233,7 +233,7 @@ public class AuthServiceImpl implements AuthService {
         return nickname != null && nickname.length() <= 10;
     }
 
-    private boolean isValidloginId(String loginId) {
+    private boolean isValidLoginId(String loginId) {
         String regex = "^(?=.*[A-Za-z])[A-Za-z\\d]{5,15}$";
         return Pattern.matches(regex, loginId);
     }

--- a/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
@@ -136,6 +136,10 @@ public class AuthServiceImpl implements AuthService {
             throw new AuthException(ErrorCode.INVALID_NICKNAME_FORMAT);
         }
 
+        if(!isValidloginId(request.getLoginId())) {
+            throw new AuthException(ErrorCode.INVALID_LOGIN_ID_FORMAT);
+        }
+
         if (!request.getPassword().equals(request.getConfirmPassword())) {
             throw new AuthException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
         }
@@ -162,6 +166,11 @@ public class AuthServiceImpl implements AuthService {
 
     private boolean isValidNickname(String nickname) {
         return nickname != null && nickname.length() <= 10;
+    }
+
+    private boolean isValidloginId(String loginId) {
+        String regex = "^(?=.*[A-Za-z])[A-Za-z\\d]{5,15}$";
+        return Pattern.matches(regex, loginId);
     }
 
     private boolean isValidPassword(String password) {

--- a/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mumuk.domain.user.service;
 
+import com.mumuk.domain.user.converter.TokenResponseConverter;
 import com.mumuk.domain.user.dto.request.AuthRequest;
 import com.mumuk.domain.user.dto.response.TokenResponse;
 import com.mumuk.domain.user.entity.User;
@@ -20,11 +21,13 @@ public class AuthServiceImpl implements AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final TokenResponseConverter tokenResponseConverter;
 
-    public AuthServiceImpl(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtTokenProvider jwtTokenProvider) {
+    public AuthServiceImpl(UserRepository userRepository, PasswordEncoder passwordEncoder, JwtTokenProvider jwtTokenProvider, TokenResponseConverter tokenResponseConverter) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.tokenResponseConverter = tokenResponseConverter;
     }
 
     @Transactional
@@ -62,12 +65,12 @@ public class AuthServiceImpl implements AuthService {
 
 
         user.updateRefreshToken(refreshToken);
-        userRepository.save(user);
+        userRepository.save(user);          // 명시적 저장
 
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("X-Refresh-Token", refreshToken);
 
-        return new TokenResponse(accessToken, refreshToken);
+        return tokenResponseConverter.toResponse(accessToken, refreshToken);
     }
 
     @Transactional
@@ -128,7 +131,7 @@ public class AuthServiceImpl implements AuthService {
         user.updateRefreshToken(newRefreshToken);
         userRepository.save(user);
 
-        return new TokenResponse(newAccessToken, newRefreshToken);
+        return tokenResponseConverter.toResponse(newAccessToken, newRefreshToken);
     }
 
     private void validateRequest(AuthRequest.SignUpReq request) {

--- a/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
@@ -25,9 +25,11 @@ public enum ErrorCode implements BaseCode {
     JWT_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "JWT_401", "유효하지 않은 JWT 토큰입니다."),
     JWT_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT_401_EX", "만료된 JWT 토큰입니다."),
 
-    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409", "이미 사용 중인 이메일입니다."),
+    LOGIN_ID_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409", "이미 사용 중인 아이디 입니다."),
+    ID_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH_400_ID_MISMATCH", "아이디가 일치하지 않습니다."),
+    PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409", "이미 가입된 휴대폰 번호 입니다."),
     PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH_400_PW_MISMATCH", "비밀번호가 일치하지 않습니다."),
-    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_400_EMAIL", "이메일 형식이 올바르지 않습니다."),
+    INVALID_LOGIN_ID_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_400_EMAIL", "아이디 형식이 올바르지 않습니다."),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_400_PW", "비밀번호는 8-15자이며 영문, 숫자, 특수문자를 포함해야 합니다."),
     INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_400_NICKNAME", "닉네임은 10자 이내만 가능합니다.");
 

--- a/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode implements BaseCode {
     ID_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH_400_ID_MISMATCH", "아이디가 일치하지 않습니다."),
     PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH_409", "이미 가입된 휴대폰 번호 입니다."),
     PASSWORD_CONFIRM_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH_400_PW_MISMATCH", "비밀번호가 일치하지 않습니다."),
-    INVALID_LOGIN_ID_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_400_EMAIL", "아이디 형식이 올바르지 않습니다."),
+    INVALID_LOGIN_ID_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_400_LOGIN_ID", "아이디 형식이 올바르지 않습니다."),
     INVALID_PASSWORD_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_400_PW", "비밀번호는 8-15자이며 영문, 숫자, 특수문자를 포함해야 합니다."),
     INVALID_NICKNAME_FORMAT(HttpStatus.BAD_REQUEST, "AUTH_400_NICKNAME", "닉네임은 10자 이내만 가능합니다.");
 

--- a/src/main/java/com/mumuk/global/apiPayload/code/ResultCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ResultCode.java
@@ -15,12 +15,13 @@ public enum ResultCode implements BaseCode {
     // User Success
     USER_FETCH_OK(HttpStatus.OK, "USER_200", "유저 정보 조회 성공"),
     TOKEN_REISSUE_OK(HttpStatus.OK, "TOKEN_200", "토큰 재발급 성공"),
+    PW_REISSUE_OK(HttpStatus.OK, "USER_200", "유저 비밀번호 변경 성공"),
     USER_LOGOUT_OK(HttpStatus.OK, "USER_200", "유저 로그아웃 성공"),
-    USER_WITHDRAW_OK(HttpStatus.OK, "USER_204", "유저 탈퇴 성공"),
+    USER_WITHDRAW_OK(HttpStatus.NO_CONTENT, "USER_204", "유저 탈퇴 성공"),
     USER_LOGIN_OK(HttpStatus.OK, "USER_200", "유저 로그인 성공"),
     USER_SIGNUP_OK(HttpStatus.CREATED, "USER_201", "유저 회원가입 성공"),
-    SEND_ID_BY_SMS_OK(HttpStatus.OK, "USER_204", "SMS 인증 발송 설공");
-
+    SEND_ID_BY_SMS_OK(HttpStatus.NO_CONTENT, "USER_204", "아이디 변경을 위한 SMS 인증 발송 성공"),
+    SEND_PW_BY_SMS_OK(HttpStatus.NO_CONTENT, "USER_204", "비밀번호 변경을 위한 SMS 인증 발송 성공");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mumuk/global/apiPayload/code/ResultCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ResultCode.java
@@ -18,7 +18,8 @@ public enum ResultCode implements BaseCode {
     USER_LOGOUT_OK(HttpStatus.OK, "USER_200", "유저 로그아웃 성공"),
     USER_WITHDRAW_OK(HttpStatus.OK, "USER_204", "유저 탈퇴 성공"),
     USER_LOGIN_OK(HttpStatus.OK, "USER_200", "유저 로그인 성공"),
-    USER_SIGNUP_OK(HttpStatus.CREATED, "USER_201", "유저 회원가입 성공");
+    USER_SIGNUP_OK(HttpStatus.CREATED, "USER_201", "유저 회원가입 성공"),
+    SEND_ID_BY_SMS_OK(HttpStatus.OK, "USER_204", "SMS 인증 발송 설공");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/mumuk/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mumuk/global/security/jwt/JwtAuthenticationFilter.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mumuk.domain.user.entity.User;
 import com.mumuk.domain.user.repository.UserRepository;
 import com.mumuk.global.apiPayload.code.ErrorCode;
-import com.mumuk.global.apiPayload.response.BaseResponse;
 import com.mumuk.global.apiPayload.exception.AuthException;
 import com.mumuk.global.apiPayload.response.Response;
 import jakarta.servlet.FilterChain;
@@ -32,7 +31,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private static final List<String> EXCLUDED_URLS = List.of(
-            "/swagger-ui", "/v3/api-docs", "/api/auth/sign-up", "/api/auth/login"
+            "/swagger-ui/**", "/v3/api-docs/**", "/api/auth/sign-up", "/api/auth/login", "/api/auth/reissue",
+            "/api/auth/recover-id", "/api/auth/recover-pw"
     );
 
     @Override
@@ -52,13 +52,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (token != null && jwtTokenProvider.validateToken(token)) {
                 String phoneNumber = jwtTokenProvider.getPhoneNumberFromToken(token);
 
-                User user = userRepository.findByLoginId(phoneNumber)
+                userRepository.findByPhoneNumber(phoneNumber)
                         .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
 
                 List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
 
                 JwtAuthenticationToken authentication =
-                        new JwtAuthenticationToken(user.getEmail(), authorities);
+                        new JwtAuthenticationToken(phoneNumber, authorities);
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }else {

--- a/src/main/java/com/mumuk/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mumuk/global/security/jwt/JwtAuthenticationFilter.java
@@ -50,9 +50,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String token = extractToken(request);
 
             if (token != null && jwtTokenProvider.validateToken(token)) {
-                String email = jwtTokenProvider.getEmailFromToken(token);
+                String phoneNumber = jwtTokenProvider.getPhoneNumberFromToken(token);
 
-                User user = userRepository.findByEmail(email)
+                User user = userRepository.findByLoginId(phoneNumber)
                         .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
 
                 List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));

--- a/src/main/java/com/mumuk/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mumuk/global/security/jwt/JwtAuthenticationFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final List<String> EXCLUDED_URLS = List.of(
             "/swagger-ui/**", "/v3/api-docs/**", "/api/auth/sign-up", "/api/auth/login", "/api/auth/reissue",
-            "/api/auth/recover-id", "/api/auth/recover-pw"
+            "/api/auth/find-id", "/api/auth/find-pw"
     );
 
     @Override

--- a/src/main/java/com/mumuk/global/security/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/mumuk/global/security/jwt/JwtAuthenticationToken.java
@@ -24,7 +24,7 @@ public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
     @Override
     public Object getPrincipal() {
-        return phoneNumber; // email이 principal
+        return phoneNumber;
     }
 
     @Override

--- a/src/main/java/com/mumuk/global/security/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/mumuk/global/security/jwt/JwtAuthenticationToken.java
@@ -10,21 +10,21 @@ import java.util.Collection;
  */
 public class JwtAuthenticationToken extends AbstractAuthenticationToken {
 
-    private final String email;
+    private final String phoneNumber;
     private final String token;
 
 
     // 인증 후(인증 완료) 토큰용 생성자
-    public JwtAuthenticationToken(String email, Collection<? extends GrantedAuthority> authorities) {
+    public JwtAuthenticationToken(String phoneNumber, Collection<? extends GrantedAuthority> authorities) {
         super(authorities);
         this.token = null;
-        this.email = email;
+        this.phoneNumber = phoneNumber;
         super.setAuthenticated(true);
     }
 
     @Override
     public Object getPrincipal() {
-        return email; // email이 principal
+        return phoneNumber; // email이 principal
     }
 
     @Override

--- a/src/main/java/com/mumuk/global/util/SmsUtil.java
+++ b/src/main/java/com/mumuk/global/util/SmsUtil.java
@@ -1,6 +1,7 @@
 package com.mumuk.global.util;
 
 import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import net.nurigo.sdk.NurigoApp;
 import net.nurigo.sdk.message.model.Message;
 import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
@@ -9,6 +10,7 @@ import net.nurigo.sdk.message.service.DefaultMessageService;
 import org.springframework.stereotype.Component;
 import org.springframework.beans.factory.annotation.Value;
 
+@Slf4j
 @Component
 public class SmsUtil {
 
@@ -33,11 +35,16 @@ public class SmsUtil {
     }
 
     public SingleMessageSentResponse sendOne(String to, String messageContent) {
-        Message message = new Message();
-        message.setFrom(senderNumber);
-        message.setTo(to);
-        message.setText(messageContent);
+        try{
+            Message message = new Message();
+            message.setFrom(senderNumber);
+            message.setTo(to);
+            message.setText(messageContent);
 
-        return this.messageService.sendOne(new SingleMessageSendingRequest(message));
+            return this.messageService.sendOne(new SingleMessageSendingRequest(message));
+        }catch (Exception e) {
+            log.error("SMS 발송 실패: to={}, message={}", to, messageContent, e);
+            throw new RuntimeException("SMS 발송에 실패했습니다.", e);
+        }
     }
 }

--- a/src/main/java/com/mumuk/global/util/SmsUtil.java
+++ b/src/main/java/com/mumuk/global/util/SmsUtil.java
@@ -1,0 +1,43 @@
+package com.mumuk.global.util;
+
+import jakarta.annotation.PostConstruct;
+import net.nurigo.sdk.NurigoApp;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.response.SingleMessageSentResponse;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+
+@Component
+public class SmsUtil {
+
+    @Value("${colsms.api.key}")
+    private String apiKey;
+
+    @Value("${colsms.api.secret}")
+    private String apiSecretKey;
+
+    @Value("${colsms.api.sender}")
+    private String senderNumber;
+
+    private DefaultMessageService messageService;
+
+    @PostConstruct
+    private void init() {
+        this.messageService = NurigoApp.INSTANCE.initialize(
+                apiKey,
+                apiSecretKey,
+                "https://api.coolsms.co.kr" // 고정된 base URL
+        );
+    }
+
+    public SingleMessageSentResponse sendOne(String to, String messageContent) {
+        Message message = new Message();
+        message.setFrom(senderNumber);
+        message.setTo(to);
+        message.setText(messageContent);
+
+        return this.messageService.sendOne(new SingleMessageSendingRequest(message));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,3 +26,9 @@ jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-validity: ${JWT_ACCESS_TOKEN_VALIDITY}    # 1시간
   refresh-token-validity: ${JWT_REFRESH_TOKEN_VALIDITY}  # 2주
+
+colsms:
+  api:
+    key: ${SMS_API_KEY}
+    secret: ${SMS_API_SECRET}
+    sender: 01087164428

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,8 +11,14 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
-
 jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-validity: ${JWT_ACCESS_TOKEN_VALIDITY}    # 1시간
   refresh-token-validity: ${JWT_REFRESH_TOKEN_VALIDITY}  # 2주
+
+
+colsms:
+  api:
+    key: ${SMS_API_KEY}
+    secret: ${SMS_API_SECRET}
+    sender: 01087164428


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #7 

## 🔑 주요 내용

![스크린샷 2025-07-08 오후 10 31 53](https://github.com/user-attachments/assets/31f9deba-99ef-4f95-b571-cc5d71038077)

기존의 email 를 입력 받아서 사용자 인증을 했던 방식에서, 휴대폰 번호를 입력 받아 ID/PW 찾기 시, SMS 인증을 통해 이루어지게 됩니다.

- SMS 문자 발송을 통한 ID/PW 기능 추가
- 비밀번호 재설정 기능 추가
- JWT 토큰 재발급 기능 추가

API 에 대한 상세 정보들은 노션 명세서를 확인해주세요 ! 


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * SMS 인증 기능이 추가되어 아이디 및 비밀번호 찾기 시 SMS로 정보를 받을 수 있습니다.
  * 아이디(로그인ID) 및 휴대폰 번호 기반 회원가입 및 로그인 기능이 도입되었습니다.
  * 토큰 재발급(리프레시) 및 비밀번호 재설정 기능이 추가되었습니다.

* **기능 개선**
  * 이메일 기반 인증이 제거되고, 로그인ID와 휴대폰 번호 기반으로 전환되었습니다.
  * 로그아웃 및 회원탈퇴 시 리프레시 토큰을 사용하도록 변경되었습니다.

* **버그 수정**
  * 중복된 로그인ID 및 휴대폰 번호에 대한 에러 메시지와 검증이 개선되었습니다.

* **문서화**
  * 모든 인증 관련 API에 Swagger 문서화가 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->