### PR TITLE
[CHORE] NCP Registry 에서 DockerHub Registry 로 저장소 변경

### DIFF
--- a/.github/workflows/mumuk-ci-cd.yml
+++ b/.github/workflows/mumuk-ci-cd.yml
@@ -57,10 +57,10 @@ jobs:
         run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
 
       - name: Build Docker image
-        run: docker build -t $DOCKERHUB_USERNAME/$IMAGE_NAME:latest .
+        run: docker build -t $DOCKERHUB_USERNAME/$IMAGE_NAME:v1.0.0 .
 
       - name: Push Docker image
-        run: docker push $DOCKERHUB_USERNAME/$IMAGE_NAME:latest
+        run: docker push $DOCKERHUB_USERNAME/$IMAGE_NAME:v1.0.0
   CD:
     needs: CI
     runs-on: ubuntu-latest
@@ -74,10 +74,10 @@ jobs:
           key: ${{ secrets.SERVER_SSH_KEY }}
           script: |
             docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}"
-            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/mumuk-backend:latest            
+            docker compose pull backend
 
             cd /home/ubuntu/BE
 
             sudo docker-compose down
-            sudo docker-compose up -d --build
+            sudo docker-compose up -d
             sudo docker image prune -f

--- a/.github/workflows/mumuk-ci-cd.yml
+++ b/.github/workflows/mumuk-ci-cd.yml
@@ -74,7 +74,7 @@ jobs:
           key: ${{ secrets.SERVER_SSH_KEY }}
           script: |
             docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}"
-            docker pull $DOCKERHUB_USERNAME/$IMAGE_NAME:latest
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/mumuk-backend:latest            
 
             cd /home/ubuntu/BE
 

--- a/.github/workflows/mumuk-ci-cd.yml
+++ b/.github/workflows/mumuk-ci-cd.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+env:
+  IMAGE_NAME: mumuk-backend
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
 jobs:
   CI:
     runs-on: ubuntu-latest
@@ -46,17 +50,17 @@ jobs:
           echo "${{ secrets.APPLICATION }}" > ./application-prod.yml
         shell: bash
 
-      - name: Build with Gradle without tests
+      - name: Build JAR
         run: ./gradlew clean bootJar -x test
 
-      - name: Copy JAR to EC2
-        uses: appleboy/scp-action@master
-        with:
-          host: ${{ secrets.SERVER_HOST }}
-          username: ${{ secrets.SERVER_USERNAME }}
-          key: ${{ secrets.SERVER_SSH_KEY }}
-          source: "build/libs/*.jar"
-          target: "/home/ubuntu/BE/build/libs/"
+      - name: Log in to DockerHub
+        run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Build Docker image
+        run: docker build -t $DOCKERHUB_USERNAME/$IMAGE_NAME:latest .
+
+      - name: Push Docker image
+        run: docker push $DOCKERHUB_USERNAME/$IMAGE_NAME:latest
   CD:
     needs: CI
     runs-on: ubuntu-latest
@@ -69,25 +73,11 @@ jobs:
           username: ${{ secrets.SERVER_USERNAME }}
           key: ${{ secrets.SERVER_SSH_KEY }}
           script: |
+            docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" -p "${{ secrets.DOCKERHUB_PASSWORD }}"
+            docker pull $DOCKERHUB_USERNAME/$IMAGE_NAME:latest
+
             cd /home/ubuntu/BE
 
-            sudo chmod -R u+w ./nginx
-
             sudo docker-compose down
-
-            git fetch origin
-            git reset --hard origin/main
-
-            ./gradlew clean bootjar
-
-            if [ "$(sudo docker ps -qa)" ]; then
-              sudo docker ps -qa | xargs -r sudo docker rm -f
-            fi
-            
-            IMAGES=$(sudo docker images -q)
-            if [ -n "$IMAGES" ]; then
-            sudo docker rmi $IMAGES
-            fi
-  
-            sudo docker-compose up --build -d
+            sudo docker-compose up -d --build
             sudo docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ dist/
 
 
 nginx/nginx.conf
+./gradle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   backend:
     container_name: backend
-    image: parkmineum/mumuk-backend:latest
+    image: parkmineum/mumuk-backend:v1.0.0
     env_file:
       - .env
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ services:
 
   backend:
     container_name: backend
-    build:
-      context: ./
-      dockerfile: Dockerfile
+    image: parkmineum/mumuk-backend:latest
     env_file:
       - .env
     expose:

--- a/src/main/java/com/mumuk/domain/user/entity/User.java
+++ b/src/main/java/com/mumuk/domain/user/entity/User.java
@@ -45,16 +45,16 @@ public class User extends BaseEntity {
 
     }
 
-    public User(String name, String nickName, String loginId, String password, String phoneNumber) {
+    public User(String name, String nickName, String phoneNumber, String loginId, String password) {
         this.name = name;
         this.nickName = nickName;
+        this.phoneNumber = phoneNumber;
         this.loginId = loginId;
         this.password = password;
-        this.phoneNumber = phoneNumber;
     }
 
-    public static User of(String name, String nickname, String loginId, String encodedPassword, String phoneNumber) {
-        return new User(name, nickname, loginId, encodedPassword, phoneNumber);
+    public static User of(String name, String nickname, String phoneNumber, String loginId, String encodedPassword) {
+        return new User(name, nickname, phoneNumber, loginId, encodedPassword);
     }
 
     public static User of(String email, String nickName, String profileImage, LoginType loginType, String socialId) {


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #14 

## 🔑 주요 내용

- Naver Cloud Platform 에서 제공하는 Registry 에 Docker 이미지를 저장하는 방식을 채택하였다가, 추후 확장성을 고려해서 Dockerhub 저장소로 변경하였습니다. 


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD 파이프라인이 개선되어, 빌드된 Docker 이미지를 DockerHub에 푸시하고, 서버에서는 이미지를 직접 받아와 배포하도록 변경되었습니다.  
  * 서버에서 직접 소스 코드를 빌드하는 단계가 제거되어 배포 과정이 단순화되고 신뢰성이 향상되었습니다.
  * `docker-compose` 설정이 변경되어, 백엔드 서비스가 로컬 빌드 대신 DockerHub에서 미리 빌드된 이미지를 사용하도록 업데이트되었습니다.
  * `.gitignore`에 `./gradle` 디렉토리가 추가되어 불필요한 파일 관리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->