### PR TITLE
[FEAT] 인증된 사용자 정보 파싱 로직 커스터마이징

### DIFF
--- a/src/main/java/com/mumuk/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.mumuk.domain.user.entity.LoginType;
 import com.mumuk.domain.user.service.AuthService;
 import com.mumuk.global.apiPayload.code.ResultCode;
 import com.mumuk.global.apiPayload.response.Response;
+import com.mumuk.global.security.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -49,9 +50,8 @@ public class AuthController {
 
     @Operation(summary = "회원 탈퇴", description = "Access Token 을 통해 사용자 인증을 검증 후 회원 탈퇴가 진행됩니다.")
     @DeleteMapping("/withdraw")
-    public Response<String> withdraw(HttpServletRequest request, @RequestHeader("X-Login-Type") LoginType loginType) {
-        String accessToken = request.getHeader("Authorization");
-        authService.withdraw(accessToken, loginType);
+    public Response<String> withdraw(@AuthUser Long userId) {
+        authService.withdraw(userId);
         return Response.ok(ResultCode.USER_WITHDRAW_OK, "회원 탈퇴가 완료되었습니다.");
     }
 
@@ -78,9 +78,8 @@ public class AuthController {
 
     @Operation(summary = "비밀번호 재설성", description = "비밀번호를 재설정합니다.")
     @PatchMapping("/reissue-pw")
-    public Response<String> reissuePassWord(@Valid @RequestBody AuthRequest.RecoverPassWordReq req, HttpServletRequest request ) {
-        String accessToken = request.getHeader("Authorization");
-        authService.reissueUserPassword(req, accessToken);
+    public Response<String> reissuePassWord(@AuthUser Long userId, @Valid @RequestBody AuthRequest.RecoverPassWordReq req, HttpServletRequest request ) {
+        authService.reissueUserPassword(req, userId);
         return Response.ok(ResultCode.PW_REISSUE_OK, "성공적으로 비밀번호가 변경되었습니다.");
     }
 }

--- a/src/main/java/com/mumuk/domain/user/controller/MypageController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/MypageController.java
@@ -9,6 +9,7 @@ import com.mumuk.domain.user.service.AuthService;
 import com.mumuk.domain.user.service.MypageService;
 import com.mumuk.global.apiPayload.code.ResultCode;
 import com.mumuk.global.apiPayload.response.Response;
+import com.mumuk.global.security.annotation.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -32,9 +33,8 @@ public class MypageController {
     // 프로필 정보 조회
     @Operation(summary = "프로필 조회", description = "사용자의 프로필 정보를 조회합니다.")
     @GetMapping
-    public Response<UserResponse.ProfileInfoDTO> profileInfo (HttpServletRequest request) {
-        String accessToken = request.getHeader("Authorization");
-        return Response.ok(mypageService.profileInfo(accessToken));
+    public Response<UserResponse.ProfileInfoDTO> profileInfo(@AuthUser Long userId) {
+        return Response.ok(mypageService.profileInfo(userId));
     }
 
     // 프로필 정보 수정

--- a/src/main/java/com/mumuk/domain/user/service/AuthService.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthService.java
@@ -10,9 +10,9 @@ public interface AuthService {
     void signUp(AuthRequest.SignUpReq request);
     TokenResponse logIn(AuthRequest.LogInReq request, HttpServletResponse response);
     void logout(String refreshToken, LoginType loginType);
-    void withdraw(String accessToken, LoginType loginType);
+    void withdraw(Long userId);
     TokenResponse reissue(String refreshToken, LoginType loginType);
     void findUserIdAndSendSms(AuthRequest.FindIdReq request);
     void findUserPassWordAndSendSms(AuthRequest.FindPassWordReq request);
-    void reissueUserPassword(AuthRequest.RecoverPassWordReq request, String accessToken);
+    void reissueUserPassword(AuthRequest.RecoverPassWordReq request, Long userId);
 }

--- a/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
@@ -72,8 +72,8 @@ public class AuthServiceImpl implements AuthService {
             throw new AuthException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);
         }
 
-        String accessToken = jwtTokenProvider.createAccessToken(user.getPhoneNumber());
-        String refreshToken = jwtTokenProvider.createRefreshToken(user.getPhoneNumber());
+        String accessToken = jwtTokenProvider.createAccessToken(user, user.getPhoneNumber());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user, user.getPhoneNumber());
 
         user.updateRefreshToken(refreshToken);
         userRepository.save(user);          // 명시적 저장
@@ -138,11 +138,11 @@ public class AuthServiceImpl implements AuthService {
         String newRefreshToken;
 
         if (loginType == LoginType.LOCAL) {
-            newAccessToken = jwtTokenProvider.createAccessToken(subject);       // phoneNumber
-            newRefreshToken = jwtTokenProvider.createRefreshToken(subject);     // phoneNumber
+            newAccessToken = jwtTokenProvider.createAccessToken(user, subject);       // phoneNumber
+            newRefreshToken = jwtTokenProvider.createRefreshToken(user, subject);     // phoneNumber
         }else{
-            newAccessToken = jwtTokenProvider.createAccessTokenByEmail(subject, loginType);       // email
-            newRefreshToken = jwtTokenProvider.createRefreshTokenByEmail(subject, loginType);     // email
+            newAccessToken = jwtTokenProvider.createAccessTokenByEmail(user, subject, loginType);       // email
+            newRefreshToken = jwtTokenProvider.createRefreshTokenByEmail(user, subject, loginType);     // email
         }
 
         // refreshToken 갱신

--- a/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
@@ -98,12 +98,9 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public void withdraw(String accessToken, LoginType loginType) {
-        if (accessToken == null || !accessToken.startsWith("Bearer ")) {
-            throw new AuthException(ErrorCode.JWT_INVALID_TOKEN);
-        }
-        User user = getUserFromToken(accessToken, loginType);
-
+    public void withdraw(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
         userRepository.delete(user);
     }
 
@@ -182,7 +179,7 @@ public class AuthServiceImpl implements AuthService {
 
     @Override
     @Transactional
-    public void reissueUserPassword(AuthRequest.RecoverPassWordReq request, String accessToken) {
+    public void reissueUserPassword(AuthRequest.RecoverPassWordReq request, Long userId) {
         String newPassword = request.getPassWord();
         String confirmPassword = request.getConfirmPassWord();
 
@@ -195,8 +192,7 @@ public class AuthServiceImpl implements AuthService {
             throw new AuthException(ErrorCode.INVALID_PASSWORD_FORMAT);
         }
 
-        String phoneNumber = jwtTokenProvider.getPhoneNumberFromToken(accessToken);
-        User user = userRepository.findByPhoneNumber(phoneNumber)
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
 
 

--- a/src/main/java/com/mumuk/domain/user/service/MypageService.java
+++ b/src/main/java/com/mumuk/domain/user/service/MypageService.java
@@ -10,6 +10,6 @@ import org.springframework.stereotype.Service;
 public interface MypageService {
 
 
-    UserResponse.ProfileInfoDTO profileInfo(String accessToken);
+    UserResponse.ProfileInfoDTO profileInfo(Long userId);
     void editProfile(MypageRequest.EditProfileReq request, String accessToken);
 }

--- a/src/main/java/com/mumuk/domain/user/service/MypageServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/user/service/MypageServiceImpl.java
@@ -32,9 +32,8 @@ public class MypageServiceImpl implements MypageService {
 
     @Override
     @Transactional
-    public UserResponse.ProfileInfoDTO profileInfo(String accessToken) {
-        String phoneNumber = jwtTokenProvider.getPhoneNumberFromToken(accessToken);
-        User user = userRepository.findByPhoneNumber(phoneNumber)
+    public UserResponse.ProfileInfoDTO profileInfo(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
         return MypageConverter.toProfileInfoDTO(user);
     }

--- a/src/main/java/com/mumuk/domain/user/service/OAuthServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/user/service/OAuthServiceImpl.java
@@ -56,8 +56,8 @@ public class OAuthServiceImpl implements OAuthService {
                 })
                 .orElseGet(() -> createNewUser(email, nickname, profileImage, LoginType.KAKAO, socialId));
 
-        String accessToken = jwtTokenProvider.createAccessTokenByEmail(user.getEmail(), LoginType.KAKAO);
-        String refreshToken = jwtTokenProvider.createRefreshTokenByEmail(user.getEmail(), LoginType.KAKAO);
+        String accessToken = jwtTokenProvider.createAccessTokenByEmail(user, user.getEmail(), LoginType.KAKAO);
+        String refreshToken = jwtTokenProvider.createRefreshTokenByEmail(user, user.getEmail(), LoginType.KAKAO);
 
         user.setRefreshToken(refreshToken);
         user.setProfileImage(profileImage);

--- a/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode implements BaseCode {
     JWT_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "JWT_500", "JWT 생성에 실패했습니다."),
     JWT_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "JWT_401", "유효하지 않은 JWT 토큰입니다."),
     JWT_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT_401_EX", "만료된 JWT 토큰입니다."),
+    JWT_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT_401", "JWT 토큰을 찾을 수 없습니다."),
+
 
     // KaKao
     KAKAO_JSON_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO_500_JSON", "카카오 프로필 파싱 중 오류가 발생했습니다."),

--- a/src/main/java/com/mumuk/global/config/WebConfig.java
+++ b/src/main/java/com/mumuk/global/config/WebConfig.java
@@ -1,16 +1,31 @@
 package com.mumuk.global.config;
 
+import com.mumuk.global.security.jwt.AuthUserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    private final AuthUserArgumentResolver userIdArgumentResolver;
+
+    public WebConfig(AuthUserArgumentResolver userIdArgumentResolver) {
+        this.userIdArgumentResolver = userIdArgumentResolver;
+    }
+
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addRedirectViewController("/swagger", "/swagger-ui/index.html");
         registry.addRedirectViewController("/swagger/", "/swagger-ui/index.html");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdArgumentResolver);
     }
 }

--- a/src/main/java/com/mumuk/global/security/annotation/AuthUser.java
+++ b/src/main/java/com/mumuk/global/security/annotation/AuthUser.java
@@ -1,0 +1,14 @@
+package com.mumuk.global.security.annotation;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import io.swagger.v3.oas.annotations.Parameter;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+public @interface AuthUser {
+}

--- a/src/main/java/com/mumuk/global/security/jwt/AuthUserArgumentResolver.java
+++ b/src/main/java/com/mumuk/global/security/jwt/AuthUserArgumentResolver.java
@@ -1,0 +1,41 @@
+package com.mumuk.global.security.jwt;
+
+import com.mumuk.global.security.annotation.AuthUser;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthUserArgumentResolver(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(AuthUser.class) != null
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) throws Exception {
+
+        String token = ((HttpServletRequest) webRequest.getNativeRequest())
+                .getHeader("Authorization");
+
+        // JWT 파싱 → userId 추출
+        return jwtTokenProvider.getUserIdFromToken(token);
+    }
+}

--- a/src/main/java/com/mumuk/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/mumuk/global/security/jwt/JwtTokenProvider.java
@@ -156,6 +156,10 @@ public class JwtTokenProvider {
     }
 
     public Long getUserIdFromToken(String token) {
+        if (token == null || token.trim().isEmpty()) {
+            throw new AuthException(ErrorCode.JWT_TOKEN_NOT_FOUND);
+        }
+
         if (token.startsWith("Bearer ")) {
             token = token.substring(7).trim();
         }


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #26 

## 🔑 주요 내용

원리는 앱 클라이언트에서 헤더로 AccessToken 을 서버로 넘겨주고, 이를 기반으로 생성된 Jwt Claim 객체에서 식별자를 꺼내게 되고, '현재 사용자' 정보가 필요한 서비스 로직에서 사용하시면 됩니다. 

JWT 파싱과 검증은 모두 별도 Resolver에서 처리하도록 분리하였고, 컨트롤러는 인자로 (@ AuthUser User userId) 와 같이 서버 자체에서 주입 받아 Serivce 로 바로 넘기는 책임만 지면 되므로, 관심사가 명확히 분리된 것을 확인할 수 있습니다. 


# 사용법

[사용 전]
```
@GetMapping
public Response<UserResponse.ProfileInfoDTO> profileInfo (HttpServletRequest request) {
    String accessToken = request.getHeader("Authorization");
    return Response.ok(mypageService.profileInfo(accessToken));
}
```
기존에는 컨트롤러가 요청을 받아 서비스에 넘기는 책임만 져야 하는데, Header 에서 직접 토큰을 꺼내서 넘겨주는 역할을 하고 있습니다.
또한, 관련 로직이 바뀔 경우 getHeader 방식의 모든 컨트롤러를 수정해야 할 수 도 있음. 


[사용 후]
```
@GetMapping
public Response<UserResponse.ProfileInfoDTO> profileInfo(@AuthUser Long userId) {
    return Response.ok(mypageService.profileInfo(userId));
}
```

그리고 관련 서비스 메서드도 수정이 가능합니다.

[사용 전]
```
@Override
@Transactional
public UserResponse.ProfileInfoDTO profileInfo(String accessToken) {
    String phoneNumber = jwtTokenProvider.getPhoneNumberFromToken(accessToken);
    User user = userRepository.findByPhoneNumber(phoneNumber)
            .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
    return MypageConverter.toProfileInfoDTO(user);
}
```

[사용 후]
```
@Override
@Transactional
public UserResponse.ProfileInfoDTO profileInfo(Long userId) {
    User user = userRepository.findById(userId)
            .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
    return MypageConverter.toProfileInfoDTO(user);
}
```

JWT 관련 빈을 주입 받아 토큰 추출을 모든 서비스 메서드에서 할 필요가 없어지고, 바로 `userId` 를 사용하도록 처리하시면 됩니다.



## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 컨트롤러 메서드에서 사용자 ID를 자동으로 주입받을 수 있는 @AuthUser 애노테이션과 ArgumentResolver가 추가되었습니다.
  * JWT 토큰에서 사용자 ID를 추출하는 기능이 추가되었습니다.

* **Bug Fixes**
  * JWT 토큰이 없을 때의 오류 코드(JWT_TOKEN_NOT_FOUND)가 추가되어, 토큰 미제공 시 명확한 에러 메시지가 제공됩니다.

* **Refactor**
  * JWT 토큰 생성 시 사용자 정보(User 객체)가 포함되어, 토큰 내에 사용자 ID가 저장됩니다.
  * 사용자 인증 관련 메서드들이 User 객체를 인자로 받아 토큰 생성에 활용하도록 변경되었습니다.
  * MypageController 및 관련 서비스에서 액세스 토큰 대신 사용자 ID를 직접 받아 처리하도록 수정되었습니다.
  * AuthController의 withdraw, reissuePassWord 메서드가 사용자 ID를 직접 받아 처리하도록 변경되었습니다.
  * Spring MVC 설정에 AuthUserArgumentResolver가 추가되어 @AuthUser 애노테이션을 통한 사용자 ID 주입을 지원합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->