### PR TITLE
[FEAT] 사용자 보유 알러지 구현

### DIFF
--- a/src/main/java/com/mumuk/MumukApplication.java
+++ b/src/main/java/com/mumuk/MumukApplication.java
@@ -2,8 +2,10 @@ package com.mumuk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
+@EntityScan("com.mumuk.domain")
 public class MumukApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/mumuk/domain/allergy/controller/AllergyController.java
+++ b/src/main/java/com/mumuk/domain/allergy/controller/AllergyController.java
@@ -1,0 +1,62 @@
+package com.mumuk.domain.allergy.controller;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.mumuk.domain.allergy.dto.request.AllergyRequest;
+import com.mumuk.domain.allergy.dto.response.AllergyResponse;
+import com.mumuk.domain.allergy.entity.AllergyType;
+import com.mumuk.domain.allergy.service.AllergyService;
+import com.mumuk.global.apiPayload.code.ErrorCode;
+import com.mumuk.global.apiPayload.code.ResultCode;
+import com.mumuk.global.apiPayload.response.Response;
+import com.mumuk.global.security.annotation.AuthUser;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.annotation.*;
+import retrofit2.http.DELETE;
+
+import static com.mumuk.global.apiPayload.response.Response.ok;
+
+@RestController
+@RequestMapping("/api/allergy")
+public class AllergyController {
+
+    private final AllergyService allergyService;
+
+    public AllergyController(AllergyService allergyService) {
+        this.allergyService = allergyService;
+    }
+
+    @PatchMapping("/{userId}/toggle")
+    public Response<AllergyResponse.ToggleResultRes> toggleAllergy(@AuthUser Long userId, @RequestBody @Valid AllergyRequest.ToggleAllergyReq request) {
+        AllergyResponse.ToggleResultRes result= allergyService.toggleAllergy(userId, request.getAllergyTypeList());
+        return Response.ok(ResultCode.ALLERGY_PATCH_OK,result);
+
+    }
+
+    @GetMapping("/{userId}")
+    public Response<AllergyResponse.AllergyListRes> getAllergy(@AuthUser Long userId) {
+        AllergyResponse.AllergyListRes allergyList=allergyService.getAllergyList(userId);
+        return Response.ok(ResultCode.ALLERGY_GET_OK, allergyList);
+    }
+
+    @Operation(summary = "알러지 없음 선택시 다른 모든 알러지 정보 초기화")
+    @DeleteMapping("/{userId}")
+    public Response<String> clearAllergy(@AuthUser Long userId) {
+        allergyService.clearAllAllergy(userId);
+        return Response.ok(ResultCode.ALLERGY_DELETE_OK, "알러지 초기화 완료");
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public Response<String> invalidAllergyInputError(HttpMessageNotReadableException e){
+
+        if (e.getCause() instanceof InvalidFormatException invalidFormatException) {
+            if (invalidFormatException.getTargetType() !=null&&invalidFormatException.getTargetType().equals(AllergyType.class)) {
+                return Response.fail(ErrorCode.ALLERGY_NOT_FOUND);
+            }
+        }
+        return Response.fail(ErrorCode.INVALID_INPUT);
+    }
+
+
+}

--- a/src/main/java/com/mumuk/domain/allergy/dto/request/AllergyRequest.java
+++ b/src/main/java/com/mumuk/domain/allergy/dto/request/AllergyRequest.java
@@ -1,0 +1,18 @@
+package com.mumuk.domain.allergy.dto.request;
+
+import com.mumuk.domain.allergy.entity.Allergy;
+import com.mumuk.domain.allergy.entity.AllergyType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+public class AllergyRequest {
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class ToggleAllergyReq {
+        private List<AllergyType> allergyTypeList;
+    }
+}

--- a/src/main/java/com/mumuk/domain/allergy/dto/response/AllergyResponse.java
+++ b/src/main/java/com/mumuk/domain/allergy/dto/response/AllergyResponse.java
@@ -1,0 +1,43 @@
+package com.mumuk.domain.allergy.dto.response;
+
+import com.mumuk.domain.allergy.entity.Allergy;
+import com.mumuk.domain.allergy.entity.AllergyType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+public class AllergyResponse {
+
+    @Getter
+    @AllArgsConstructor
+    public static class AllergyListRes{
+        private List<AllergyOption> allergyOptions;
+        @Getter
+        @AllArgsConstructor
+        public static class AllergyOption{
+
+            private Long id;
+            private AllergyType allergyType;
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class ToggleResultRes{
+        private List<ToggleResult> results;
+
+        @Getter
+        @AllArgsConstructor
+        public static class ToggleResult{
+            private AllergyType allergyType;
+            private String action;
+        }
+    }
+
+
+
+
+}

--- a/src/main/java/com/mumuk/domain/allergy/entity/Allergy.java
+++ b/src/main/java/com/mumuk/domain/allergy/entity/Allergy.java
@@ -1,0 +1,43 @@
+package com.mumuk.domain.allergy.entity;
+
+import com.mumuk.domain.user.entity.User;
+import com.mumuk.global.common.BaseEntity;
+import jakarta.persistence.*;
+
+@Entity
+@Table(name="allergy")
+public class Allergy extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="알러지 이름", nullable=false)
+    private AllergyType allergyType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name="user_id", nullable=false)
+    private User user;
+
+    //생성자
+    public Allergy() {}
+
+    public Allergy(AllergyType allergyType, User user) {
+        this.allergyType = allergyType;
+        this.user = user;
+    }
+
+    //getter
+    public Long getId() {return id;};
+    public AllergyType getAllergyType() {return allergyType;}
+    public User getUser() {return user;};
+
+
+    //setter
+    public void setId(Long id) {this.id = id;};
+    public void setAllergyType(AllergyType allergyType) {this.allergyType = allergyType;};
+    public void setUser(User user) {this.user = user;};
+
+}

--- a/src/main/java/com/mumuk/domain/allergy/entity/AllergyType.java
+++ b/src/main/java/com/mumuk/domain/allergy/entity/AllergyType.java
@@ -1,0 +1,15 @@
+package com.mumuk.domain.allergy.entity;
+
+public enum AllergyType {
+
+    SHELLFISH,
+    NUTS,
+    DAIRY,
+    WHEAT,
+    EGG,
+    FISH,
+    SOY,
+    NONE;
+
+
+}

--- a/src/main/java/com/mumuk/domain/allergy/repository/AllergyRepository.java
+++ b/src/main/java/com/mumuk/domain/allergy/repository/AllergyRepository.java
@@ -1,0 +1,24 @@
+package com.mumuk.domain.allergy.repository;
+
+import com.mumuk.domain.allergy.entity.Allergy;
+import com.mumuk.domain.allergy.entity.AllergyType;
+import com.mumuk.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface AllergyRepository extends JpaRepository<Allergy, Long> {
+    List<Allergy> findByUser(User user);
+    List<Allergy> findByUserId(Long userId);
+
+    Optional<Allergy> findByUserAndAllergyType(User user, AllergyType allergyType);
+    boolean existsByUserAndAllergyType(User user, AllergyType allergyType);
+    void deleteByUserAndAllergyType(User user, AllergyType allergyType);
+
+    void deleteByUser(User user);
+
+}

--- a/src/main/java/com/mumuk/domain/allergy/service/AllergyService.java
+++ b/src/main/java/com/mumuk/domain/allergy/service/AllergyService.java
@@ -1,0 +1,13 @@
+package com.mumuk.domain.allergy.service;
+
+import com.mumuk.domain.allergy.dto.response.AllergyResponse;
+import com.mumuk.domain.allergy.entity.AllergyType;
+
+import java.util.List;
+
+public interface AllergyService {
+
+    AllergyResponse.AllergyListRes getAllergyList(Long userId);
+    AllergyResponse.ToggleResultRes toggleAllergy(Long userId, List<AllergyType> allergyTypeList);
+    void clearAllAllergy(Long userId);
+}

--- a/src/main/java/com/mumuk/domain/allergy/service/AllergyServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/allergy/service/AllergyServiceImpl.java
@@ -1,0 +1,94 @@
+package com.mumuk.domain.allergy.service;
+
+import com.mumuk.domain.allergy.dto.response.AllergyResponse;
+import com.mumuk.domain.allergy.entity.Allergy;
+import com.mumuk.domain.allergy.entity.AllergyType;
+import com.mumuk.domain.allergy.repository.AllergyRepository;
+import com.mumuk.domain.user.entity.User;
+import com.mumuk.domain.user.repository.UserRepository;
+import com.mumuk.global.apiPayload.code.ErrorCode;
+import com.mumuk.global.security.exception.AuthException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class AllergyServiceImpl implements AllergyService {
+
+    private final AllergyRepository allergyRepository;
+    private final UserRepository userRepository;
+
+    public AllergyServiceImpl(AllergyRepository allergyRepository, UserRepository userRepository) {
+        this.allergyRepository = allergyRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public AllergyResponse.AllergyListRes getAllergyList(Long userId) {
+        User user=userRepository.findById(userId)
+                .orElseThrow(()->new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        List<Allergy> allergyList = allergyRepository.findByUser(user);
+
+        // 알러지 목록과 선택 여부까지 불러오도록
+        List<AllergyResponse.AllergyListRes.AllergyOption> allergyListRes = allergyList.stream()
+                .map(allergy -> new AllergyResponse.AllergyListRes.AllergyOption(
+                        allergy.getId(),
+                        allergy.getAllergyType()))
+
+                .collect(Collectors.toList());
+
+        return new AllergyResponse.AllergyListRes(allergyListRes);
+    }
+
+    @Override
+    @Transactional
+    public AllergyResponse.ToggleResultRes toggleAllergy(Long userId, List<AllergyType> allergyTypeList) {
+        User user=userRepository.findById(userId)
+                .orElseThrow(()->new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        List<AllergyResponse.ToggleResultRes.ToggleResult> ToggleResultList=new ArrayList<>();
+
+        // 입력받은 여러 알러지를 한 번에 처리
+        for (AllergyType allergyType:allergyTypeList) {
+
+            // 알러지가 존재하는지 판단
+            Optional<Allergy> existAllergy=allergyRepository.findByUserAndAllergyType(user,allergyType);
+
+            if (existAllergy.isPresent()) {
+                // 알러지가 존재한다면, 제거
+                allergyRepository.delete(existAllergy.get());
+                ToggleResultList.add(new AllergyResponse.ToggleResultRes.ToggleResult(allergyType,"DELETE"));
+            } else{
+                // "알러지 없음" 이 선택되어 있다면, 이를 먼저 삭제
+                Optional<Allergy> noneAllergy=allergyRepository.findByUserAndAllergyType(user, AllergyType.NONE);
+                if (noneAllergy.isPresent()){
+                    allergyRepository.deleteByUserAndAllergyType(user,AllergyType.NONE);
+                }
+
+                //알러지가 존재하지 않는다면 해당 알러지 추가
+                Allergy newAllergy=new Allergy(allergyType,user);
+                allergyRepository.save(newAllergy);
+                ToggleResultList.add(new AllergyResponse.ToggleResultRes.ToggleResult(allergyType,"ADD"));
+            }
+        }
+
+        return new AllergyResponse.ToggleResultRes(ToggleResultList);
+    }
+
+    @Override
+    @Transactional
+    public void clearAllAllergy(Long userId) {
+        // 알러지 정보 초기화, None 선택시 다른 선택된 알러지 초기화 용도
+        User user=userRepository.findById(userId)
+                .orElseThrow(()->new AuthException(ErrorCode.USER_NOT_FOUND));
+        allergyRepository.deleteByUser(user);
+    }
+
+}

--- a/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
@@ -63,7 +63,11 @@ public enum ErrorCode implements BaseCode {
 
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "SEARCH_400", "단어를 한 글자 이상 입력해야 합니다."),
     SEARCH_LOG_NOT_FOUND(HttpStatus.NOT_FOUND, "SEARCH_404", "사용자의 검색 기록이 존재하지 않습니다." ),
-    SEARCH_LOG_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "SEARCH_404", "해당 사용자가 존재하지 않습니다." );
+    SEARCH_LOG_USER_NOT_FOUND(HttpStatus.NOT_FOUND, "SEARCH_404", "해당 사용자가 존재하지 않습니다." ),
+
+    //Allergy Error
+    ALLERGY_NOT_FOUND(HttpStatus.BAD_REQUEST,"ALLERGY_404", "해당 알러지 타입은 존재하지 않습니다,");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/mumuk/global/apiPayload/code/ResultCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ResultCode.java
@@ -35,7 +35,12 @@ public enum ResultCode implements BaseCode {
     SEARCH_AUTOCOMPLETE_OK(HttpStatus.OK, "SEARCH_200","자동완성 성공"),
     SEARCH_SAVE_RECENTSEARCHES_OK(HttpStatus.CREATED,"SEARCH_201", "최근 검색어 저장 성공"),
     SEARCH_DELETE_RECENTSEARCHES_OK(HttpStatus.NO_CONTENT,"SEARCH_204", "최근 검색어 삭제 성공"),
-    SEARCH_GET_RECENTSEARCHES_OK(HttpStatus.OK,"SEARCH_200", "최근 검색어 조회 성공");
+    SEARCH_GET_RECENTSEARCHES_OK(HttpStatus.OK,"SEARCH_200", "최근 검색어 조회 성공"),
+
+    //Allergy Success
+    ALLERGY_PATCH_OK(HttpStatus.CREATED, "ALLERGY_200","알러지 정보 변경 성공"),
+    ALLERGY_DELETE_OK(HttpStatus.NO_CONTENT, "ALLERGY_204","알러지 정보 삭제 성공"),
+    ALLERGY_GET_OK(HttpStatus.OK, "ALLERGY_200","알러지 정보 조회 성공");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/mumuk/global/config/DataInitializer.java
+++ b/src/main/java/com/mumuk/global/config/DataInitializer.java
@@ -14,6 +14,8 @@ public class DataInitializer implements CommandLineRunner {
     private final RedisTemplate<String, String> redisTemplate;
     private static final String ZSET_KEY="autocomplete";
 
+
+
     /*
     DB에 있는 데이터를 redis에 추가하는 코드는 추후에 작성하겠습니다..
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,4 +52,4 @@ openai:
   api:
     key: ${OPEN_AI_KEY}
     url: https://api.openai.com/v1
-    model: gpt-3.5-turbo
+  model: gpt-3.5-turbo


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #29 

## 🔑 주요 내용

- figma 상에 존재했던 알러지들을 enum으로 만들어 관리했습니다. 알러지를 추가해야 한다면 enum에 추가해야 합니다.
- 알러지 종류를 토글할 수 있게 만들었습니다. 특정 알러지를 입력했을 때, 해당 알러지가 db상에 존재한다면 삭제합니다. 만약 존재하지 않는다면 해당 알러지를 추가합니다.
- enum에 등록하지 않는 알러지를 입력시 예외를 던집니다. 이 예외는 Json에서 자바 객체로 변환하는 중에 발생하는 예외인지라, service 단에서 처리하지 못 하고 controller 단에서 처리하게 되었습니다. 

<img width="679" height="785" alt="image" src="https://github.com/user-attachments/assets/f4330994-b2cc-4e99-b766-378933b36690" />

db상에 존재하지 않는 알러지의 경우, 추가합니다. 
<img width="677" height="658" alt="image" src="https://github.com/user-attachments/assets/29a5ca0a-ec6c-40b7-a002-7bd126adbe74" />
get으로 확인해보니, db상에 잘 등록되어 있음을 알 수 있습니다.

<img width="650" height="689" alt="image" src="https://github.com/user-attachments/assets/c4351f8e-a8cb-4a0f-87d3-d852569ea136" />
<img width="682" height="575" alt="image" src="https://github.com/user-attachments/assets/8a97d0a0-3302-4ea0-9ed5-868347682574" />

같은 알러지를 또다시 입력시, 해당 알러지가 삭제됨을 알 수 있습니다. response를 다르게 하여 알러지 추가/삭제를 알아보기 쉽게 하였습니다.

<img width="676" height="578" alt="image" src="https://github.com/user-attachments/assets/41488863-ff26-42c1-a34e-64f8ae6909bb" />
모든 알러지 정보 초기화 기능입니다.
프론트 단에서 "알러지 없음" 선택시, 해당 api를 통해 선택한 모든 알러지를 선택해제 할 때 유용할 것 같아 만들었습니다.

<img width="686" height="721" alt="image" src="https://github.com/user-attachments/assets/692a1b79-b700-47fc-88ca-6e94e893f155" />
enum에 등록하지 않은 입력을 던질 때, 존재하지 않는 알러지 타입 예외를 던집니다. 이는 Json에서 java 객체로 전환하는 도중 발생하는 예외로, service 단을 거치지 않기에 부득이하게 controller 단에 예외설정을 했습니다.



## Check List

- [X] **Reviewers** 등록을 하였나요?
- [X] **Assignees** 등록을 하였나요?
- [X] **라벨(Label)** 등록을 하였나요?
- [X] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!