### PR TITLE
[REFACTOR] 소셜 로그인 State 값 검증 및 환경 분리

### DIFF
--- a/src/main/java/com/mumuk/domain/user/controller/OAuthController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/OAuthController.java
@@ -24,15 +24,15 @@ public class OAuthController {
 
     @Operation(summary = "카카오 로그인", description = "카카오 서버로부터 인가코드를 받아 이를 기반으로 로그인 처리")
     @PostMapping("/kakao-login")
-    public Response<UserResponse.JoinResultDTO> kakaoLogin(@RequestParam("code") String accessCode, HttpServletResponse httpServletResponse) {
-        User user = oAuthService.oAuthKaKaoLogin(accessCode, httpServletResponse);
+    public Response<UserResponse.JoinResultDTO> kakaoLogin(@RequestParam("code") String accessCode, @RequestParam("state") String state, HttpServletResponse httpServletResponse) {
+        User user = oAuthService.oAuthKaKaoLogin(accessCode, state, httpServletResponse);
         return Response.ok(OAuthConverter.toJoinResultDTO(user));
     }
 
     @Operation(summary = "네이버 로그인", description = "네이버 서버로부터 인가코드를 받아 이를 기반으로 로그인 처리")
     @PostMapping("/naver-login")
-    public Response<UserResponse.JoinResultDTO> naverLogin(@RequestParam("code") String accessCode,@RequestParam("state") String state, HttpServletResponse httpServletResponse) {
-        User user = oAuthService.oAuthNaverLogin(accessCode,state, httpServletResponse);
+    public Response<UserResponse.JoinResultDTO> naverLogin(@RequestParam("code") String accessCode, @RequestParam("state") String state, HttpServletResponse httpServletResponse) {
+        User user = oAuthService.oAuthNaverLogin(accessCode, state, httpServletResponse);
         return Response.ok(OAuthConverter.toJoinResultDTO(user));
     }
 }

--- a/src/main/java/com/mumuk/domain/user/service/OAuthService.java
+++ b/src/main/java/com/mumuk/domain/user/service/OAuthService.java
@@ -4,7 +4,7 @@ import com.mumuk.domain.user.entity.User;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface OAuthService {
-    User oAuthKaKaoLogin(String accessCode, HttpServletResponse response);
+    User oAuthKaKaoLogin(String accessCode, String state,  HttpServletResponse response);
 
     User oAuthNaverLogin(String accessCode, String state, HttpServletResponse httpServletResponse);
 }

--- a/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
@@ -40,7 +40,7 @@ public enum ErrorCode implements BaseCode {
     KAKAO_INVALID_GRANT(HttpStatus.UNAUTHORIZED, "KAKAO_401_INVALID_GRANT", "유효하지 않거나 만료된 인가 코드입니다."),
     KAKAO_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "KAKAO_401_AUTH_FAILED", "카카오 인증에 실패했습니다."),
     ALREADY_REGISTERED_WITH_OTHER_LOGIN(HttpStatus.CONFLICT, "AUTH_409_ALREADY_REGISTERED", "해당 이메일은 다른 로그인 방식으로 이미 가입되어 있습니다."),
-    SOCIAL_LOGIN_INVALID_STATE(HttpStatus.UNAUTHORIZED, "KAKAO_401_INVALID_GRANT", "유효하지 않거나 만료된 STATE 값입니다.."),
+    SOCIAL_LOGIN_INVALID_STATE(HttpStatus.UNAUTHORIZED, "SOCIAL_401_INVALID_GRANT", "유효하지 않거나 만료된 STATE 값입니다.."),
 
     // Naver
     NAVER_JSON_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_500_JSON", "네이버 프로필 파싱 중 오류가 발생했습니다."),

--- a/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
@@ -40,6 +40,7 @@ public enum ErrorCode implements BaseCode {
     KAKAO_INVALID_GRANT(HttpStatus.UNAUTHORIZED, "KAKAO_401_INVALID_GRANT", "유효하지 않거나 만료된 인가 코드입니다."),
     KAKAO_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "KAKAO_401_AUTH_FAILED", "카카오 인증에 실패했습니다."),
     ALREADY_REGISTERED_WITH_OTHER_LOGIN(HttpStatus.CONFLICT, "AUTH_409_ALREADY_REGISTERED", "해당 이메일은 다른 로그인 방식으로 이미 가입되어 있습니다."),
+    SOCIAL_LOGIN_INVALID_STATE(HttpStatus.UNAUTHORIZED, "KAKAO_401_INVALID_GRANT", "유효하지 않거나 만료된 STATE 값입니다.."),
 
     // Naver
     NAVER_JSON_PARSE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "NAVER_500_JSON", "네이버 프로필 파싱 중 오류가 발생했습니다."),

--- a/src/main/java/com/mumuk/global/security/oauth/util/NaverUtil.java
+++ b/src/main/java/com/mumuk/global/security/oauth/util/NaverUtil.java
@@ -23,6 +23,7 @@ import java.util.Set;
 public class NaverUtil {
 
     private final ObjectMapper objectMapper;
+    private final StateUtil stateUtil;
 
 
     @Value("${naver.login.client-id}")
@@ -31,8 +32,9 @@ public class NaverUtil {
     private String clientSecret;
 
 
-    public NaverUtil(ObjectMapper objectMapper) {
+    public NaverUtil(ObjectMapper objectMapper, StateUtil stateUtil) {
         this.objectMapper = objectMapper;
+        this.stateUtil = stateUtil;
     }
 
     /**
@@ -41,6 +43,10 @@ public class NaverUtil {
      */
     public NaverResponse.OAuthToken requestToken(String accessCode, String state) {
 
+        if (!stateUtil.isValidUUID(state)) {
+            log.error("[🚨ERROR🚨] 유효하지 않은 state 값 (UUID 아님): {}", state);
+            throw new AuthFailureHandler(ErrorCode.SOCIAL_LOGIN_INVALID_STATE);
+        }
 
         // 요청 헤더 및 파라미터 구성
         RestTemplate restTemplate = new RestTemplate();

--- a/src/main/java/com/mumuk/global/security/oauth/util/StateUtil.java
+++ b/src/main/java/com/mumuk/global/security/oauth/util/StateUtil.java
@@ -1,0 +1,18 @@
+package com.mumuk.global.security.oauth.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class StateUtil {
+
+    public boolean isValidUUID(String state) {
+        try {
+            UUID.fromString(state);    // 파싱 시도 → 실패하면 예외
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,7 +18,9 @@ spring:
       host: redis
       port: 6379
 
-
+naver:
+  login:
+    redirect-uri: mumukapp://naver
 
 kakao:
   native-app-key: ${KAKAO_NATIVE_APP_KEY}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,7 +21,7 @@ spring:
 
 
 kakao:
-  native-app-key: ${KAKAO_SECRET_KEY}
-  redirect-uri: https://api.mumuk.site/login/oauth2/code/kakao
+  native-app-key: ${KAKAO_NATIVE_APP_KEY}
+  redirect-uri: kakao${KAKAO_NATIVE_APP_KEY}://oauth
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #40 

## 🔑 주요 내용

- State 값 검증 
- 원할한 테스트를 위해 개발 환경(Web Secret Key), 운영 환경(Native App Key) 로 분리
- Redirect Uri 변경 


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 소셜 로그인 시 state 파라미터 유효성 검증이 도입되었습니다.
  * state 값이 UUID 형식이 아닐 경우 새로운 에러 메시지가 제공됩니다.

* **버그 수정**
  * 카카오 및 네이버 로그인에서 유효하지 않은 state 값으로 인한 로그인 오류가 방지됩니다.

* **환경설정**
  * 카카오 네이티브 앱 키 환경변수명과 리다이렉트 URI가 사용자 맞춤형 스킴으로 변경되었습니다.
  * 네이버 로그인 리다이렉트 URI가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->