### PR TITLE
[REFACTOR] 인기 검색어 조회시, 현재 시각까지 반환하도록 수정, 컨트롤러명 수정

### DIFF
--- a/src/main/java/com/mumuk/domain/allergy/controller/AllergyController.java
+++ b/src/main/java/com/mumuk/domain/allergy/controller/AllergyController.java
@@ -18,7 +18,7 @@ import retrofit2.http.DELETE;
 import static com.mumuk.global.apiPayload.response.Response.ok;
 
 @RestController
-@RequestMapping("/api/allergy")
+@RequestMapping("/api/allergies")
 public class AllergyController {
 
     private final AllergyService allergyService;
@@ -28,7 +28,7 @@ public class AllergyController {
     }
 
     @Operation(summary = "사용자의 알러지 정보 선택/취소", description = "사용자가 가진 특정 알러지에 대해서, 해당 알러지기 이미 존재한다면 삭제, 존재하지 않는다면 추가")
-    @PatchMapping("/toggle")
+    @PatchMapping
     public Response<AllergyResponse.ToggleResultRes> toggleAllergy(@AuthUser Long userId, @RequestBody @Valid AllergyRequest.ToggleAllergyReq request) {
         AllergyResponse.ToggleResultRes result= allergyService.toggleAllergy(userId, request.getAllergyTypeList());
         return Response.ok(ResultCode.ALLERGY_PATCH_OK,result);
@@ -36,14 +36,14 @@ public class AllergyController {
     }
 
     @Operation(summary = "사용자의 알러지 정보 조회")
-    @GetMapping("/get")
+    @GetMapping
     public Response<AllergyResponse.AllergyListRes> getAllergy(@AuthUser Long userId) {
         AllergyResponse.AllergyListRes allergyList=allergyService.getAllergyList(userId);
         return Response.ok(ResultCode.ALLERGY_GET_OK, allergyList);
     }
 
     @Operation(summary = "사용자의 모든 알러지 정보 초기화", description = "알러지 없음 선택시, 사용자의 다른 모든 알러지 정보를 제거하기 위함")
-    @DeleteMapping("/deleteAll")
+    @DeleteMapping
     public Response<String> clearAllergy(@AuthUser Long userId) {
         allergyService.clearAllAllergy(userId);
         return Response.ok(ResultCode.ALLERGY_DELETE_OK, "알러지 초기화 완료");

--- a/src/main/java/com/mumuk/domain/search/controller/SearchController.java
+++ b/src/main/java/com/mumuk/domain/search/controller/SearchController.java
@@ -2,6 +2,7 @@ package com.mumuk.domain.search.controller;
 
 import com.mumuk.domain.recipe.dto.response.RecipeResponse;
 import com.mumuk.domain.search.dto.request.SearchRequest;
+import com.mumuk.domain.search.dto.response.SearchResponse;
 import com.mumuk.domain.search.service.AutocompleteService;
 import com.mumuk.domain.search.service.RecentSearchService;
 import com.mumuk.domain.search.service.SearchService;
@@ -34,9 +35,7 @@ public class SearchController {
 
     @Operation(summary = "레시피 검색결과 목록 조회")
     @GetMapping("/recipe/search")
-    public Response<List<RecipeResponse.SimpleRes>> showResultList( @AuthUser Long userId,  @RequestParam String keyword) {
-
-        recentSearchService.saveRecentSearch(userId, keyword);
+    public Response<List<RecipeResponse.SimpleRes>> showResultList( @RequestParam String keyword) {
         List<RecipeResponse.SimpleRes> resultList= searchService.SearchRecipeList(keyword);
         return Response.ok(ResultCode.SEARCH_RECIPE_OK, resultList);
     }
@@ -82,8 +81,8 @@ public class SearchController {
 
     @Operation(summary = "인기 검색어 조회")
     @GetMapping("/search-trends")
-    public Response<List<String>> getTrend(){
-        List<String> trendKeywords=trendSearchService.getTrendKeyword();
+    public Response<SearchResponse.TrendKeywordListRes> getTrend(){
+        SearchResponse.TrendKeywordListRes trendKeywords=trendSearchService.getTrendKeyword();
         return Response.ok(ResultCode.TRENDKEYWORDS_OK ,trendKeywords);
     }
 }

--- a/src/main/java/com/mumuk/domain/search/controller/SearchController.java
+++ b/src/main/java/com/mumuk/domain/search/controller/SearchController.java
@@ -80,7 +80,7 @@ public class SearchController {
     }
 
     @Operation(summary = "인기 검색어 조회")
-    @GetMapping("/search-trends")
+    @GetMapping("/trends")
     public Response<SearchResponse.TrendKeywordListRes> getTrend(){
         SearchResponse.TrendKeywordListRes trendKeywords=trendSearchService.getTrendKeyword();
         return Response.ok(ResultCode.TRENDKEYWORDS_OK ,trendKeywords);

--- a/src/main/java/com/mumuk/domain/search/controller/SearchController.java
+++ b/src/main/java/com/mumuk/domain/search/controller/SearchController.java
@@ -34,21 +34,21 @@ public class SearchController {
     }
 
     @Operation(summary = "레시피 검색결과 목록 조회")
-    @GetMapping("/recipe/search")
+    @GetMapping("/recipes")
     public Response<List<RecipeResponse.SimpleRes>> showResultList( @RequestParam String keyword) {
         List<RecipeResponse.SimpleRes> resultList= searchService.SearchRecipeList(keyword);
         return Response.ok(ResultCode.SEARCH_RECIPE_OK, resultList);
     }
 
     @Operation(summary = "레시피 검색결과 세부 조회")
-    @GetMapping("/recipe/{recipeId}")
+    @GetMapping("/recipes/{recipeId}")
     public Response<RecipeResponse.DetailRes> showDetailResult(@RequestParam Long recipeId) {
         RecipeResponse.DetailRes detailResult= searchService.SearchDetailRecipe(recipeId);
         return Response.ok(ResultCode.SEARCH_DETAILRECIPE_OK,detailResult);
     }
 
     @Operation(summary = "레시피 자동완성 기능")
-    @GetMapping("/recipe/autocomplete")
+    @GetMapping("/recipes/autocomplete")
     public Response<List<String>> getAutocompleteSuggestions(@RequestParam String userInput) {
 
         List<String> suggestions = autocompleteService.getAutocompleteSuggestions(userInput);

--- a/src/main/java/com/mumuk/domain/search/dto/response/SearchResponse.java
+++ b/src/main/java/com/mumuk/domain/search/dto/response/SearchResponse.java
@@ -1,0 +1,27 @@
+package com.mumuk.domain.search.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+@Getter
+public class SearchResponse {
+
+    @Getter
+    @AllArgsConstructor
+    public static class TrendKeywordListRes {
+        private final List<String> trendKeywordList;
+        private final LocalDateTime localDateTime;
+
+        public TrendKeywordListRes(List<String> trendKeywordList) {
+            this.trendKeywordList = trendKeywordList;
+            this.localDateTime = LocalDateTime.now();
+        }
+    }
+
+
+
+}

--- a/src/main/java/com/mumuk/domain/search/service/TrendSearchService.java
+++ b/src/main/java/com/mumuk/domain/search/service/TrendSearchService.java
@@ -1,9 +1,11 @@
 package com.mumuk.domain.search.service;
 
+import com.mumuk.domain.search.dto.response.SearchResponse;
+
 import java.util.List;
 
 public interface TrendSearchService {
     public void increaseKeywordCount(String keyword);
-    public List<String> getTrendKeyword();
+    public SearchResponse.TrendKeywordListRes getTrendKeyword();
 
 }

--- a/src/main/java/com/mumuk/domain/search/service/TrendSearchServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/TrendSearchServiceImpl.java
@@ -1,5 +1,6 @@
 package com.mumuk.domain.search.service;
 
+import com.mumuk.domain.search.dto.response.SearchResponse;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -29,8 +30,11 @@ public class TrendSearchServiceImpl implements TrendSearchService {
 
     @Override
     @Scheduled(cron = "0 0 * * * *")
-    public List<String> getTrendKeyword() {
+    public SearchResponse.TrendKeywordListRes getTrendKeyword() {
         Set<String> trendKeywordSet = redisTemplate.opsForZSet().reverseRange(KEY,0,9);
-        return new ArrayList<>(trendKeywordSet);
+        // 순서 보장 위해 리스트로 한 번 변환
+        List<String> trendKeywordList = new ArrayList<>(trendKeywordSet);
+
+        return new SearchResponse.TrendKeywordListRes(trendKeywordList);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #60 

## 🔑 주요 내용

-
<img width="680" height="676" alt="image" src="https://github.com/user-attachments/assets/9982329d-d3ec-4ea4-92ed-067ebd7227fb" />
인기 검색어 반환시 현재 시각까지 반환하도록 수정

기타 수정사항
컨트롤러명을 좀 더 restful하게 변경
- 인기 검색어 조회 search/search-trends에서 search/trends로
- 레시피 검색 관련 url을 search/recipes로
- 알러지 관련 url을 /allergies로



## Check List

- [X] **Reviewers** 등록을 하였나요?
- [X] **Assignees** 등록을 하였나요?
- [X] **라벨(Label)** 등록을 하였나요?
- [X] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!