### PR TITLE
[SETTING] Prometheus & Grafana 모니터링 환경 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,12 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+
+	// Monitoring
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,35 @@ services:
       timeout: 10s
       retries: 3
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - "9090:9090"
+    networks:
+      - mumuk_network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - mumuk_network
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD}
+      - GF_SERVER_DOMAIN=grafana.mumuk.site
+      - GF_SERVER_ROOT_URL=https://grafana.mumuk.site/
+volumes:
+  grafana-storage:
+
 networks:
   mumuk_network:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   nginx:
     container_name: nginx
-    image: nginx:latest
+    image: nginx:1.29.0
     ports:
       - "90:80"
       - "443:443"
@@ -55,7 +55,7 @@ services:
       retries: 3
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.5.0
     container_name: prometheus
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
@@ -67,7 +67,7 @@ services:
       - mumuk_network
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:12.1.0
     container_name: grafana
     ports:
       - "3000:3000"

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s       # 매트릭 수집 주기
+
+scrape_configs:
+  - job_name: 'springboot-backend'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['backend:8080']
+
+  - job_name: 'prometheus-self'
+    static_configs:
+      - targets: [ 'localhost:9090' ]

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,3 +64,10 @@ openai:
     key: ${OPEN_AI_KEY}
     url: https://api.openai.com/v1
     model: gpt-3.5-turbo
+
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #43 

## 🔑 주요 내용

Docker Network 내부에서 WAS 는 `/actuator/prometheus` 경로로 텍스트 형식의 매트릭 데이터를 노출하게 되고, Prometheus 가 
실시간으로 Pull 하여 정보를 수집하게 됩니다. 

Grafana 는 Prometheus 가 수집한 매트릭 데이터들을 가져와 시각화하게 됩니다. 

운영 환경에서 각 모니터링 시스템에 접근하기 위해서는` https://prometheus/도메인` , `https://grafana/도메인` 으로 접근이 가능하고,
이를 위해 Nginx 내부에 별도의 Server 블록으로 분리해주었습니다. 세부 설정은 CD Workflow 이후에 세팅하겠습니다 ! 


<img width="623" height="353" alt="image" src="https://github.com/user-attachments/assets/f7f858be-a1e6-43c3-8a5e-270a34083e7c" />

비슷한 그림을 가져와봤는데, 저희는 Grafana 와 WAS 모두 443 port(HTTPS) 로 들어가게 되고, WAS 앞에 Nginx 가 있습니다 ! 


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * Prometheus 및 Grafana 서비스를 추가하여 애플리케이션 모니터링 및 시각화 기능을 도입했습니다.
  * Prometheus가 Spring Boot 백엔드 및 자체 메트릭을 수집하도록 구성되었습니다.
  * Grafana의 데이터가 영구적으로 저장되도록 스토리지 볼륨이 추가되었습니다.

* **설정**
  * Prometheus 메트릭 엔드포인트가 노출되도록 애플리케이션 설정이 확장되었습니다.
  * Nginx 서비스 이미지 버전이 최신에서 1.29.0으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->