### PR TITLE
[REFACTOR] Nginx SSL 인증서 경로 마운트

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,7 @@ services:
       - "443:443"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - /etc/letsencrypt/live/api.mumuk.site:/etc/letsencrypt/live/api.mumuk.site:ro
-      - /etc/letsencrypt/archive:/etc/letsencrypt/archive:ro
-      - /etc/letsencrypt/privkey.pem:/etc/letsencrypt/privkey.pem:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     environment:
       - TZ=Asia/Seoul
     networks:


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #64 

## 🔑 주요 내용

- Prometheus 와 Grafana 에 대해 각 도메인 url 을 분리하였기에, Lets encrypt 하위 경로들을 인식 할 수 있도록 통일하였습니다. 


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Nginx 서비스의 Let's Encrypt 인증서 볼륨 마운트 구성을 단일 디렉터리 마운트로 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->