### PR TITLE
[REFACTOR] 비밀번호 확인 과정 api 분리

### DIFF
--- a/src/main/java/com/mumuk/domain/user/controller/AuthController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/AuthController.java
@@ -76,6 +76,13 @@ public class AuthController {
         return Response.ok(ResultCode.SEND_PW_BY_SMS_OK, "SMS 메시지로 PW의 일부를 확인하실 수 있습니다.");
     }
 
+    @Operation(summary = "현재 비밀번호 확인", description = "사용자의 현재 비밀번호를 확인합니다.")
+    @PostMapping("/check-current-pw")
+    public Response<String> checkCurrentPassword(@AuthUser Long userId, @Valid @RequestBody AuthRequest.CheckCurrentPasswordReq req) {
+        authService.checkCurrentPassword(req, userId);
+        return Response.ok(ResultCode.PASSWORD_CHECK_OK, "현재 비밀번호가 일치합니다.");
+    }
+
     @Operation(summary = "비밀번호 재설성", description = "비밀번호를 재설정합니다.")
     @PatchMapping("/reissue-pw")
     public Response<String> reissuePassWord(@AuthUser Long userId, @Valid @RequestBody AuthRequest.RecoverPassWordReq req) {

--- a/src/main/java/com/mumuk/domain/user/dto/request/AuthRequest.java
+++ b/src/main/java/com/mumuk/domain/user/dto/request/AuthRequest.java
@@ -68,10 +68,16 @@ public class AuthRequest {
     @Getter
     @Setter
     @NoArgsConstructor
-    public static class RecoverPassWordReq {
+    public static class CheckCurrentPasswordReq {
 
         @NotBlank
-        private String currentPassWord;
+        private String currentPassword;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class RecoverPassWordReq {
 
         @NotBlank
         private String newPassWord;

--- a/src/main/java/com/mumuk/domain/user/service/AuthService.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthService.java
@@ -14,5 +14,6 @@ public interface AuthService {
     TokenResponse reissue(String refreshToken, LoginType loginType);
     void findUserIdAndSendSms(AuthRequest.FindIdReq request);
     void findUserPassWordAndSendSms(AuthRequest.FindPassWordReq request);
+    void checkCurrentPassword(AuthRequest.CheckCurrentPasswordReq request, Long userId);
     void reissueUserPassword(AuthRequest.RecoverPassWordReq request, Long userId);
 }

--- a/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/user/service/AuthServiceImpl.java
@@ -178,18 +178,26 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public void checkCurrentPassword(AuthRequest.CheckCurrentPasswordReq request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        String currentPassword = request.getCurrentPassword();
+
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new AuthException(ErrorCode.INVALID_CURRENT_PASSWORD_FORMAT);
+        }
+    }
+
+    @Override
     @Transactional
     public void reissueUserPassword(AuthRequest.RecoverPassWordReq request, Long userId) {
-        String currentPassword = request.getCurrentPassWord();
         String newPassword = request.getNewPassWord();
         String confirmPassword = request.getConfirmPassWord();
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
-
-        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
-            throw new AuthException(ErrorCode.INVALID_CURRENT_PASSWORD_FORMAT);
-        }
 
         if (!newPassword.equals(confirmPassword)) {
             throw new AuthException(ErrorCode.PASSWORD_CONFIRM_MISMATCH);

--- a/src/main/java/com/mumuk/global/apiPayload/code/ResultCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ResultCode.java
@@ -25,6 +25,7 @@ public enum ResultCode implements BaseCode {
     USER_WITHDRAW_OK(HttpStatus.NO_CONTENT, "USER_204", "유저 탈퇴 성공"),
     USER_LOGIN_OK(HttpStatus.OK, "USER_200", "유저 로그인 성공"),
     USER_SIGNUP_OK(HttpStatus.CREATED, "USER_201", "유저 회원가입 성공"),
+    PASSWORD_CHECK_OK(HttpStatus.OK, "USER_200", "올바른 비밀번호를 입력하였습니다."),
 
     SEND_ID_BY_SMS_OK(HttpStatus.NO_CONTENT, "USER_204", "아이디 변경을 위한 SMS 인증 발송 성공"),
     SEND_PW_BY_SMS_OK(HttpStatus.NO_CONTENT, "USER_204", "비밀번호 변경을 위한 SMS 인증 발송 성공"),


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #75 

## 🔑 주요 내용

- 비밀번호 확인 절차에서 현재 비밀번호 입력 하는 과정 분리 


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 현재 비밀번호를 확인하는 API 엔드포인트가 추가되었습니다.
* **버그 수정**
  * 비밀번호 변경 시, 기존 비밀번호 확인이 별도의 엔드포인트로 분리되었습니다.
* **기타**
  * 비밀번호 관련 요청 형식이 명확하게 구분되어 개선되었습니다.
  * 비밀번호 확인 성공 시 반환되는 메시지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->