### PR TITLE
[REFACTOR] 검색 목록 반환시 찜하기 여부까지 반환하도록 수정

### DIFF
--- a/src/main/java/com/mumuk/domain/search/controller/SearchController.java
+++ b/src/main/java/com/mumuk/domain/search/controller/SearchController.java
@@ -38,6 +38,7 @@ public class SearchController {
     @GetMapping("/recipes")
     public Response<List<UserRecipeResponse.RecentRecipeDTO>> showResultList(@AuthUser Long userId, @RequestParam String keyword) {
         List<UserRecipeResponse.RecentRecipeDTO> resultList= searchService.SearchRecipeList(userId, keyword);
+        recentSearchService.saveRecentSearch(userId, keyword);
         return Response.ok(ResultCode.SEARCH_RECIPE_OK, resultList);
     }
 

--- a/src/main/java/com/mumuk/domain/search/controller/SearchController.java
+++ b/src/main/java/com/mumuk/domain/search/controller/SearchController.java
@@ -4,6 +4,7 @@ import com.mumuk.domain.recipe.dto.response.RecipeResponse;
 import com.mumuk.domain.search.dto.request.SearchRequest;
 import com.mumuk.domain.search.dto.response.SearchResponse;
 import com.mumuk.domain.search.service.*;
+import com.mumuk.domain.user.dto.response.UserRecipeResponse;
 import com.mumuk.domain.user.entity.User;
 import com.mumuk.global.apiPayload.code.ResultCode;
 import com.mumuk.global.apiPayload.response.Response;
@@ -35,8 +36,8 @@ public class SearchController {
 
     @Operation(summary = "레시피 검색결과 목록 조회")
     @GetMapping("/recipes")
-    public Response<List<RecipeResponse.SimpleRes>> showResultList( @RequestParam String keyword) {
-        List<RecipeResponse.SimpleRes> resultList= searchService.SearchRecipeList(keyword);
+    public Response<List<UserRecipeResponse.RecentRecipeDTO>> showResultList(@AuthUser Long userId, @RequestParam String keyword) {
+        List<UserRecipeResponse.RecentRecipeDTO> resultList= searchService.SearchRecipeList(userId, keyword);
         return Response.ok(ResultCode.SEARCH_RECIPE_OK, resultList);
     }
 

--- a/src/main/java/com/mumuk/domain/search/service/SearchService.java
+++ b/src/main/java/com/mumuk/domain/search/service/SearchService.java
@@ -1,12 +1,13 @@
 package com.mumuk.domain.search.service;
 
 import com.mumuk.domain.recipe.dto.response.RecipeResponse;
+import com.mumuk.domain.user.dto.response.UserRecipeResponse;
 
 import java.util.List;
 
 public interface SearchService {
 
-    List<RecipeResponse.SimpleRes> SearchRecipeList(String keyword);
+    List<UserRecipeResponse.RecentRecipeDTO> SearchRecipeList(Long userId, String keyword);
 
     RecipeResponse.DetailRes SearchDetailRecipe(Long recipeId);
 

--- a/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
@@ -58,7 +58,7 @@ public class SearchServiceImpl implements SearchService {
                     // 좋아요 여부 입력받기
                     UserRecipe userRecipe = userRecipeMap.get(recipe.getId());
                     boolean isLiked=(userRecipe!=null)&&userRecipe.getLiked();
-                    return new UserRecipeResponse.RecentRecipeDTO(recipe.getId(),recipe.getRecipeImage(),recipe.getTitle(),isLiked);
+                    return new UserRecipeResponse.RecentRecipeDTO(recipe.getId(),recipe.getTitle(),recipe.getRecipeImage(),isLiked);
                 }).collect(Collectors.toList());
 
         return recipeList;

--- a/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
@@ -34,7 +34,7 @@ public class SearchServiceImpl implements SearchService {
     public List<UserRecipeResponse.RecentRecipeDTO> SearchRecipeList(Long userId, String keyword) {
 
         // 검색어가 존재한다면, 해당 검색어 조회수를 1 추가
-        if (!(keyword == null || keyword.isEmpty())) {
+        if (!(keyword == null || keyword.isBlank())) {
             trendSearchService.increaseKeywordCount(keyword);
         }
         // 키워드를 바탕으로 결과값 반환

--- a/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
@@ -3,27 +3,35 @@ package com.mumuk.domain.search.service;
 import com.mumuk.domain.recipe.dto.response.RecipeResponse;
 import com.mumuk.domain.recipe.repository.RecipeRepository;
 import com.mumuk.domain.recipe.service.RecipeService;
+import com.mumuk.domain.user.dto.response.UserRecipeResponse;
+import com.mumuk.domain.user.entity.UserRecipe;
+import com.mumuk.domain.user.repository.UserRecipeRepository;
+import com.mumuk.domain.user.repository.UserRepository;
 import com.mumuk.global.apiPayload.code.ErrorCode;
 import com.mumuk.global.apiPayload.exception.GlobalException;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class SearchServiceImpl implements SearchService {
 
     private final RecipeRepository recipeRepository;
+    private final UserRecipeRepository userRecipeRepository;
     private final TrendSearchService trendSearchService;
     private final RecipeService recipeService;
 
-    public SearchServiceImpl(RecipeRepository recipeRepository, TrendSearchService trendSearchService, RecipeService recipeService) {
+    public SearchServiceImpl(RecipeRepository recipeRepository, UserRecipeRepository userRecipeRepository, TrendSearchService trendSearchService, RecipeService recipeService) {
         this.recipeRepository = recipeRepository;
+        this.userRecipeRepository = userRecipeRepository;
         this.trendSearchService = trendSearchService;
         this.recipeService = recipeService;
     }
 
     @Override
-    public List<RecipeResponse.SimpleRes> SearchRecipeList(String keyword) {
+    public List<UserRecipeResponse.RecentRecipeDTO> SearchRecipeList(Long userId, String keyword) {
 
         // 검색어가 존재한다면, 해당 검색어 조회수를 1 추가
         if (!(keyword == null || keyword.isEmpty())) {
@@ -31,11 +39,24 @@ public class SearchServiceImpl implements SearchService {
         }
 
         // 키워드를 바탕으로 결과값 반환
-        List<RecipeResponse.SimpleRes> recipeList= recipeRepository.findByTitleContainingIgnoreCase(keyword);
+        List<RecipeResponse.SimpleRes> recipes= recipeRepository.findByTitleContainingIgnoreCase(keyword);
 
-        if (recipeList.isEmpty()) {
+        if (recipes.isEmpty()) {
             throw new GlobalException(ErrorCode.SEARCH_RESULT_NOT_FOUND);
         }
+
+        List<UserRecipe> userRecipes =userRecipeRepository.findByUserIdAndRecipeIdIn(userId, recipes.stream().map(RecipeResponse.SimpleRes::getId).collect(Collectors.toList()));
+
+        Map<Long, UserRecipe> userRecipeMap = userRecipes.stream()
+                .collect(Collectors.toMap(userRecipe -> userRecipe.getRecipe().getId(), userRecipe -> userRecipe));
+
+        List<UserRecipeResponse.RecentRecipeDTO> recipeList = recipes.stream()
+                .map(recipe -> {
+                    UserRecipe userRecipe = userRecipeMap.get(recipe.getId());
+                    boolean isLiked=(userRecipe!=null)&&userRecipe.getLiked();
+                    return new UserRecipeResponse.RecentRecipeDTO(recipe.getId(),recipe.getRecipeImage(),recipe.getTitle(),isLiked);
+                }).collect(Collectors.toList());
+
         return recipeList;
     }
 

--- a/src/main/java/com/mumuk/domain/user/repository/UserRecipeRepository.java
+++ b/src/main/java/com/mumuk/domain/user/repository/UserRecipeRepository.java
@@ -1,6 +1,5 @@
 package com.mumuk.domain.user.repository;
 
-import com.mumuk.domain.recipe.dto.response.RecipeResponse;
 import com.mumuk.domain.user.dto.response.UserRecipeResponse;
 import com.mumuk.domain.user.entity.UserRecipe;
 import org.springframework.data.domain.Page;


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #78 

## 🔑 주요 내용

- 레시피 검색 목록 반환시, 찜하기 여부까지 반환하도록 dto 변경
<img width="872" height="788" alt="image" src="https://github.com/user-attachments/assets/a51c3c33-4cd0-4bf9-a8a4-9b01b7d8ef6f" />



## Check List

- [X] **Reviewers** 등록을 하였나요?
- [X] **Assignees** 등록을 하였나요?
- [X] **라벨(Label)** 등록을 하였나요?
- [X] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 레시피 검색 결과에 사용자가 해당 레시피를 좋아요(Like) 했는지 여부가 함께 표시됩니다.

* **버그 수정**
  * 없음

* **기타**
  * 검색 결과가 사용자 맞춤형 정보(좋아요 여부 포함)로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->