### PR TITLE
[REFACTOR] 알러지 목록 토글 대신 삭제 후 재입력으로 변경

### DIFF
--- a/src/main/java/com/mumuk/domain/allergy/controller/AllergyController.java
+++ b/src/main/java/com/mumuk/domain/allergy/controller/AllergyController.java
@@ -28,7 +28,7 @@ public class AllergyController {
     }
 
     @Operation(summary = "사용자의 알러지 정보 선택/취소", description = "사용자가 가진 특정 알러지에 대해서, 해당 알러지기 이미 존재한다면 삭제, 존재하지 않는다면 추가")
-    @PatchMapping
+    @PutMapping
     public Response<AllergyResponse.ToggleResultRes> toggleAllergy(@AuthUser Long userId, @RequestBody @Valid AllergyRequest.ToggleAllergyReq request) {
         AllergyResponse.ToggleResultRes result= allergyService.toggleAllergy(userId, request.getAllergyTypeList());
         return Response.ok(ResultCode.ALLERGY_PATCH_OK,result);

--- a/src/main/java/com/mumuk/domain/allergy/entity/Allergy.java
+++ b/src/main/java/com/mumuk/domain/allergy/entity/Allergy.java
@@ -5,7 +5,7 @@ import com.mumuk.global.common.BaseEntity;
 import jakarta.persistence.*;
 
 @Entity
-@Table(name="allergy")
+@Table(name="allergy", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id","allergy_type"}))
 public class Allergy extends BaseEntity {
 
     @Id
@@ -14,7 +14,7 @@ public class Allergy extends BaseEntity {
 
 
     @Enumerated(EnumType.STRING)
-    @Column(name="알러지 이름", nullable=false)
+    @Column(name="allergy_type", nullable=false)
     private AllergyType allergyType;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/mumuk/domain/allergy/service/AllergyServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/allergy/service/AllergyServiceImpl.java
@@ -64,6 +64,7 @@ public class AllergyServiceImpl implements AllergyService {
 
         // 사용자의 기존 알러지 정보 삭제
         allergyRepository.deleteByUser(user);
+        allergyRepository.flush();
 
         // 입력받은 알러지 타입 정보 목록에 대해서, 하나하나 알러지 객체 목록으로 변환
         List<Allergy> allergyList = allergyTypeList.stream()
@@ -72,6 +73,7 @@ public class AllergyServiceImpl implements AllergyService {
 
         // 알러지 객체 목록 데이터베이스에 저장
         allergyRepository.saveAll(allergyList);
+        allergyRepository.flush();
 
         // 입력한 알러지 객체 목록 반환
         List<AllergyResponse.ToggleResultRes.ToggleResult> toggleResultList = allergyTypeList.stream()


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #82 

## 🔑 주요 내용

- 알러지 목록 갱신시 기존의 방법에 의하면, 이미 선택되어있는 알러지 재선택시 삭제, 선택되지 않은 알러지 선택시 추가하는 형식으로, 알러지가 토글되도록 설계하였습니다. 
- 바오님의 요청으로 알러지 선택시, 기존 알러지를 초기화하고 새로 입력한 알러지만 추가되도록 기능을 수정하였습니다. 
<img width="686" height="777" alt="image" src="https://github.com/user-attachments/assets/501dade2-9d4e-46b5-be07-ff3fe28d0497" />
알러지 등록시, 기존 알러지는 모두 삭제되고 새 알러지만 등록됩니다
<img width="668" height="516" alt="image" src="https://github.com/user-attachments/assets/1f92c565-1964-4031-83bb-776f78799f7f" />




## Check List

- [X] **Reviewers** 등록을 하였나요?
- [X] **Assignees** 등록을 하였나요?
- [X] **라벨(Label)** 등록을 하였나요?
- [X] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 알러지 토글 엔드포인트의 HTTP 메서드가 PATCH에서 PUT으로 변경되었습니다.

* **스타일**
  * 알러지 엔터티의 컬럼명이 영어로 변경되고, user_id와 allergy_type 조합에 대한 유니크 제약 조건이 추가되었습니다.

* **리팩터**
  * 알러지 토글 기능이 기존의 토글 방식에서 전체 교체 방식으로 동작하도록 개선되었습니다. 이제 선택한 알러지 목록이 기존 알러지를 모두 대체합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->