### PR TITLE
[SETTING] Loki & Grafana WAS 컨테이너 로그 모니터링 서버 구축

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,6 +105,8 @@ services:
     ports:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
+    volumes:
+      - ./loki:/loki
     networks:
       - mumuk_network
 
@@ -113,8 +115,9 @@ services:
     container_name: promtail
     volumes:
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ./promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml:ro
+      - ./promtail/positions.yaml:/etc/promtail/positions.yaml
     command: -config.file=/etc/promtail/promtail-config.yaml
     networks:
       - mumuk_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,26 @@ services:
     networks:
       - mumuk_network
 
+  loki:
+    image: grafana/loki:2.9.2
+    container_name: loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+    networks:
+      - mumuk_network
+
+  promtail:
+    image: grafana/promtail:2.9.2
+    container_name: promtail
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./promtail/promtail-config.yaml:/etc/promtail/promtail-config.yaml
+    command: -config.file=/etc/promtail/promtail-config.yaml
+    networks:
+      - mumuk_network
+
   grafana:
     image: grafana/grafana:12.1.0
     container_name: grafana

--- a/promtail/promtail-config.yaml
+++ b/promtail/promtail-config.yaml
@@ -1,0 +1,20 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: backend-logs
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+    relabel_configs:
+      - source_labels: [__meta_docker_container_name]
+        regex: /backend
+        action: keep
+    pipeline_stages:
+      - docker: {}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #89 

## 🔑 주요 내용

내부 로직은 Promtail 컨테이너가 WAS 컨테이너의 로그를 Docker의 Socket 기능을 통해 주기적으로 JSON 형식으로 수집하고,
Loki 컨테이너로 로그를 전송합니다. 이후 Grafana 에서 Loki 로그 데이터를 조회하게 됩니다. 

기존에 Docker 내부 접속을 통해서 운영 환경의 로그들을 확인해왔는데, Loki & Grafana 를 통해 인증된 사용자들은 내부 로그를 배포된 Grafana 를 통해 확인이 가능해집니다. 
 


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loki 및 Promtail 로그 집계 및 수집 기능이 추가되었습니다.
  * 새로운 로그 모니터링 서비스를 위한 설정 파일이 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->