### PR TITLE
[REFACTOR] 추천 검색어 반환시, 최근 조회한 레시피의 여러 카테고리들도 반영할 수 있도록 변경

### DIFF
--- a/src/main/java/com/mumuk/domain/allergy/controller/AllergyController.java
+++ b/src/main/java/com/mumuk/domain/allergy/controller/AllergyController.java
@@ -27,7 +27,7 @@ public class AllergyController {
         this.allergyService = allergyService;
     }
 
-    @Operation(summary = "사용자의 알러지 정보 선택/취소", description = "사용자가 가진 특정 알러지에 대해서, 해당 알러지기 이미 존재한다면 삭제, 존재하지 않는다면 추가")
+    @Operation(summary = "사용자의 알러지 정보 선택", description = "사용자가 기존에 가진 알러지를 모두 삭제하고 현재 선택한 알러지만 추가")
     @PutMapping
     public Response<AllergyResponse.ToggleResultRes> toggleAllergy(@AuthUser Long userId, @RequestBody @Valid AllergyRequest.ToggleAllergyReq request) {
         AllergyResponse.ToggleResultRes result= allergyService.toggleAllergy(userId, request.getAllergyTypeList());

--- a/src/main/java/com/mumuk/domain/search/controller/SearchController.java
+++ b/src/main/java/com/mumuk/domain/search/controller/SearchController.java
@@ -42,7 +42,7 @@ public class SearchController {
         return Response.ok(ResultCode.SEARCH_RECIPE_OK, resultList);
     }
 
-    @Operation(summary = "레시피 검색결과 세부 조회")
+    @Operation(summary = "레시피 검색결과 세부 조회" ,description="사용 x, user-recipe 컨트롤러의 레시피 상세 조회로 통합")
     @GetMapping("/recipes/{recipeId}")
     public Response<RecipeResponse.DetailRes> showDetailResult(@PathVariable Long recipeId) {
         RecipeResponse.DetailRes detailResult= searchService.SearchDetailRecipe(recipeId);

--- a/src/main/java/com/mumuk/domain/search/service/RecommendedRecipeServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/RecommendedRecipeServiceImpl.java
@@ -36,9 +36,13 @@ public class RecommendedRecipeServiceImpl implements RecommendedRecipeService {
             return List.of(); // 카테고리가 없으면 빈 리스트 반환
         }
 
+        List<String> categoryNameList = categories.stream()
+                .map(RecipeCategory::name)
+                .toList();
+
         // 레포지토리에서 random을 사용하기 때문에 naviveQuery를 사용,
         // nativeQuery 사용 과정에서 enum 변환에 문제가 생길 수 있기 때문에 카테고리 이름만 넘김
-        List<Recipe> randomRecipes = recipeRepository.findRandomRecipesByCategories(categories, recipeId);
+        List<Recipe> randomRecipes = recipeRepository.findRandomRecipesByCategories(categoryNameList, recipeId);
 
         // recipeList에서 레시피 제목 (String)만 꺼내서 추출하려고 함
         // 이때 추천 검색어에는 항상 다른 레시피들이 추출되었으면 좋겠음


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #96 

## 🔑 주요 내용

- 추천 검색어 기능 로직은
1. 최근 검색한 레시피 조회
2. 해당 레시피의 카테고리 추출
3. 해당 레시피를 제외하고, 같은 카테고리의 다른 레시피 6개 반환
이었는데, 한 레시피가 여러 개의 카테고리를 가질 수 있게 되면서 기능이 작동하지 않게 되었습니다.

이에 최근 검색한 레시피가 가진 카테고리들을 List 로 추출하여, 해당 카테고리에 속하는 레시피들을 6개 반환하도록 수정하였습니다

<img width="653" height="687" alt="image" src="https://github.com/user-attachments/assets/072ac8b3-e70b-4c09-855d-f76e93826397" />



## Check List

- [X] **Reviewers** 등록을 하였나요?
- [X] **Assignees** 등록을 하였나요?
- [X] **라벨(Label)** 등록을 하였나요?
- [X] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!