### PR TITLE
[SETTING] K6  부하 테스트 환경 구축

### DIFF
--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -15,21 +15,6 @@ services:
     networks:
       - monitoring
 
-  grafana:
-    image: grafana/grafana
-    container_name: grafana-k6
-    ports:
-      - "8080:3000" # Grafana 대시보드: http://localhost:8080
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=1234
-    depends_on:
-      - influxdb
-    volumes:
-      - grafana-storage:/var/lib/grafana
-    networks:
-      - monitoring
-
   k6:
     image: grafana/k6
     container_name: k6
@@ -40,9 +25,6 @@ services:
       - influxdb
     networks:
       - monitoring
-
-volumes:
-  grafana-storage:
 
 networks:
   monitoring:

--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -12,3 +12,5 @@ services:
 
 networks:
   monitoring:
+
+# docker run --rm -v "$PWD/k6:/scripts" grafana/k6 run /scripts/스크립트 파일명

--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -1,28 +1,12 @@
 version: '3'
 
 services:
-  influxdb:
-    image: influxdb:1.8
-    container_name: influxdb
-    ports:
-      - "8086:8086"
-    environment:
-      - INFLUXDB_DB=k6
-      - INFLUXDB_USER=k6
-      - INFLUXDB_USER_PASSWORD=1234
-      - INFLUXDB_ADMIN_USER=admin
-      - INFLUXDB_ADMIN_PASSWORD=1234
-    networks:
-      - monitoring
-
   k6:
     image: grafana/k6
     container_name: k6
     volumes:
       - ./k6:/scripts
     entrypoint: ["k6", "run", "--out", "influxdb=http://influxdb:8086/k6", "/scripts/test.js"]
-    depends_on:
-      - influxdb
     networks:
       - monitoring
 

--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -17,10 +17,11 @@ services:
 
   grafana:
     image: grafana/grafana
-    container_name: grafana
+    container_name: grafana-k6
     ports:
       - "8080:3000" # Grafana 대시보드: http://localhost:8080
     environment:
+      - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=1234
     depends_on:
       - influxdb

--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -6,7 +6,7 @@ services:
     container_name: k6
     volumes:
       - ./k6:/scripts
-    entrypoint: ["k6", "run", "--out", "influxdb=http://influxdb:8086/k6", "/scripts/test.js"]
+    entrypoint: [ "k6", "run", "/scripts/test.js" ]
     networks:
       - monitoring
 

--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -24,6 +24,8 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=1234
     depends_on:
       - influxdb
+    volumes:
+      - grafana-storage:/var/lib/grafana
     networks:
       - monitoring
 
@@ -37,6 +39,9 @@ services:
       - influxdb
     networks:
       - monitoring
+
+volumes:
+  grafana-storage:
 
 networks:
   monitoring:

--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -1,0 +1,42 @@
+version: '3'
+
+services:
+  influxdb:
+    image: influxdb:1.8
+    container_name: influxdb
+    ports:
+      - "8086:8086"
+    environment:
+      - INFLUXDB_DB=k6
+      - INFLUXDB_USER=k6
+      - INFLUXDB_USER_PASSWORD=1234
+      - INFLUXDB_ADMIN_USER=admin
+      - INFLUXDB_ADMIN_PASSWORD=1234
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    ports:
+      - "8080:3000" # Grafana 대시보드: http://localhost:8080
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=1234
+    depends_on:
+      - influxdb
+    networks:
+      - monitoring
+
+  k6:
+    image: grafana/k6
+    container_name: k6
+    volumes:
+      - ./k6:/scripts
+    entrypoint: ["k6", "run", "--out", "influxdb=http://influxdb:8086/k6", "/scripts/test.js"]
+    depends_on:
+      - influxdb
+    networks:
+      - monitoring
+
+networks:
+  monitoring:

--- a/k6/test.js
+++ b/k6/test.js
@@ -1,0 +1,15 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+export let options = {
+    vus: 10,
+    duration: '10s',
+};
+
+export default function () {
+    const res = http.get('http://host.docker.internal:8080/');
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+    });
+    sleep(1);
+}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #63 

## 🔑 주요 내용

부하 테스트이기에 별도의 docker-compose.k6.yml 에 세팅하였고, CD 워크플로우에 포함이 안되므로 개발 환경에서만 사용하도록 하였습니다. 

[사용 방법] 
-  k6 디렉토리 내부에 .js 타입의 테스트 스크립트 작성 
- `docker run --rm -v "$PWD/k6:/scripts" grafana/k6 run /scripts/test.js`

스크립트 수정 후에도 동일 명령어로 실행해주시면 됩니다. (k6 컨테이너는 결과 화면 출력 후 알아서 꺼져요)


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * k6 부하 테스트를 위한 Docker Compose 설정이 추가되었습니다.
  * 10명의 가상 사용자가 10초 동안 지정된 엔드포인트에 대해 성능 테스트를 수행하는 k6 스크립트가 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->