### PR TITLE
[REFACTOR] 카카오 & 네이버 소셜 로그인 인증 플로우 SDK 요청에 맞게 리팩토링

### DIFF
--- a/src/main/java/com/mumuk/domain/user/controller/OAuthController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/OAuthController.java
@@ -20,16 +20,16 @@ public class OAuthController {
     }
 
     @Operation(summary = "카카오 로그인", description = "카카오 서버로부터 인가코드를 받아 이를 기반으로 로그인 처리")
-    @GetMapping("/kakao/callback")
-    public Response<UserResponse.JoinResultDTO> kakaoLogin(@RequestParam("code") String accessCode, @RequestParam("state") String state) {
-        UserResponse.JoinResultDTO result = oAuthService.oAuthKaKaoLogin(accessCode, state);
+    @GetMapping("/kakao-login")
+    public Response<UserResponse.JoinResultDTO> kakaoLogin(@RequestParam("access_token") String accessToken, @RequestParam("state") String state) {
+        UserResponse.JoinResultDTO result = oAuthService.oAuthKaKaoLoginWithAccessToken(accessToken, state);
         return Response.ok(result);
     }
 
     @Operation(summary = "네이버 로그인", description = "네이버 서버로부터 인가코드를 받아 이를 기반으로 로그인 처리")
-    @GetMapping("/naver/callback")
-    public Response<UserResponse.JoinResultDTO> naverLogin(@RequestParam("code") String accessCode, @RequestParam("state") String state) {
-        UserResponse.JoinResultDTO result = oAuthService.oAuthNaverLogin(accessCode, state);
+    @GetMapping("/naver-login")
+    public Response<UserResponse.JoinResultDTO> naverLogin(@RequestParam("access_token") String accessToken, @RequestParam("state") String state) {
+        UserResponse.JoinResultDTO result = oAuthService.oAuthNaverLogin(accessToken, state);
         return Response.ok(result);
     }
 }

--- a/src/main/java/com/mumuk/domain/user/dto/response/KaKaoResponse.java
+++ b/src/main/java/com/mumuk/domain/user/dto/response/KaKaoResponse.java
@@ -7,13 +7,6 @@ public class KaKaoResponse {
 
     @Getter
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class OAuthToken {
-        private String access_token;
-        private String refresh_token;
-    }
-
-    @Getter
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class KakaoProfile {
         private Long id; // 소셜 ID
 

--- a/src/main/java/com/mumuk/domain/user/dto/response/NaverResponse.java
+++ b/src/main/java/com/mumuk/domain/user/dto/response/NaverResponse.java
@@ -7,13 +7,6 @@ public class NaverResponse {
 
     @Getter
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public static class OAuthToken {
-        private String access_token;
-        private String refresh_token;
-    }
-
-    @Getter
-    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class NaverProfile {
         private String resultcode;
         private String message;

--- a/src/main/java/com/mumuk/domain/user/service/OAuthService.java
+++ b/src/main/java/com/mumuk/domain/user/service/OAuthService.java
@@ -4,6 +4,6 @@ import com.mumuk.domain.user.dto.response.UserResponse;
 import com.mumuk.domain.user.entity.User;
 
 public interface OAuthService {
-    UserResponse.JoinResultDTO oAuthKaKaoLogin(String accessCode, String state);
-    UserResponse.JoinResultDTO oAuthNaverLogin(String accessCode, String state);
+    UserResponse.JoinResultDTO oAuthKaKaoLoginWithAccessToken(String accessToken, String state);
+    UserResponse.JoinResultDTO oAuthNaverLogin(String accessToken, String state);
 }

--- a/src/main/java/com/mumuk/global/security/oauth/util/KaKaoUtil.java
+++ b/src/main/java/com/mumuk/global/security/oauth/util/KaKaoUtil.java
@@ -27,15 +27,10 @@ import java.util.UUID;
 public class KaKaoUtil {
 
     private final ObjectMapper objectMapper;
-    private final StateUtil stateUtil;
 
-    public KaKaoUtil(ObjectMapper objectMapper, StateUtil stateUtil) {
+    public KaKaoUtil(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.stateUtil = stateUtil;
     }
-
-    @Value("${kakao.native-app-key}")
-    private String clientId;
 
     @Value("${kakao.redirect-uri}")
     private String redirectUri;
@@ -50,92 +45,33 @@ public class KaKaoUtil {
     }
 
     /**
-     *  인가 코드를 이용해 카카오 서버로부터 OAuth 토큰 반환 받음.
-     *  추후 OAuth Token 을 이용해, 카카오 서버로부터 사용자 정보 반환 => DB 저장 및 자체 인증/인가 로직
-     */
-    public KaKaoResponse.OAuthToken requestToken(String accessCode, String state, String redirectUri) {
-
-        redirectUri = redirectUri.trim();
-
-        if (!allowedRedirectUris.contains(redirectUri)) {
-            log.error("[🚨ERROR🚨] 허용되지 않은 redirect_uri 요청: {}", redirectUri);
-            throw new AuthFailureHandler(ErrorCode.KAKAO_INVALID_GRANT);
-        }
-
-        if (!stateUtil.isValidUUID(state)) {
-            log.error("[🚨ERROR🚨] 유효하지 않은 state 값 (UUID 아님): {}", state);
-            throw new AuthFailureHandler(ErrorCode.SOCIAL_LOGIN_INVALID_STATE);
-        }
-
-        // 요청 헤더 및 파라미터 구성
-        RestTemplate restTemplate = new RestTemplate();
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("redirect_uri", redirectUri);
-        params.add("code", accessCode);
-
-        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
-
-        try {
-            // 카카오 토큰 엔드포인트에 POST 요청
-            ResponseEntity<String> response = restTemplate.exchange(
-                    "https://kauth.kakao.com/oauth/token",
-                    HttpMethod.POST,
-                    kakaoTokenRequest,
-                    String.class
-            );
-
-            log.info("[RESPONSE] 카카오 API 응답: {}", response.getBody());
-
-            if (response.getStatusCode() != HttpStatus.OK) {
-                throw new AuthFailureHandler(ErrorCode.KAKAO_AUTH_FAILED);
-            }
-
-            // 정상 응답일 경우, 카카오 서버의 JSON 응답을 객체 형태로 역직렬화하여 반환
-            return objectMapper.readValue(response.getBody(), KaKaoResponse.OAuthToken.class);
-
-        } catch (HttpClientErrorException.Unauthorized e) {
-            log.error("[🚨ERROR🚨] 유효하지 않은 카카오 인증 코드 (401 Unauthorized)");
-            throw new AuthFailureHandler(ErrorCode.KAKAO_INVALID_GRANT);
-        } catch (JsonProcessingException e) {
-            log.error("[🚨ERROR🚨] 카카오 응답 JSON 파싱 오류: {}", e.getMessage());
-            throw new AuthFailureHandler(ErrorCode.KAKAO_JSON_PARSE_ERROR);
-        } catch (Exception e) {
-            log.error("[🚨ERROR🚨] 카카오 API 호출 중 오류 발생: {}", e.getMessage());
-            throw new AuthFailureHandler(ErrorCode.KAKAO_API_ERROR);
-        }
-    }
-
-
-    /**
      *  access token 을 사용해 카카오 사용자 정보 요청
      */
-    public KaKaoResponse.KakaoProfile requestProfile(KaKaoResponse.OAuthToken oAuthToken) {
-
-        if (oAuthToken == null || oAuthToken.getAccess_token() == null) {
-            throw new AuthFailureHandler(ErrorCode.KAKAO_AUTH_FAILED);
-        }
+    public KaKaoResponse.KakaoProfile requestProfileWithAccessToken(String accessToken) {
 
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
+
+        headers.add("Authorization", "Bearer " + accessToken);
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-        headers.add("Authorization", "Bearer " + oAuthToken.getAccess_token());
-        HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
 
         try {
             ResponseEntity<String> response = restTemplate.exchange(
                     "https://kapi.kakao.com/v2/user/me",
                     HttpMethod.GET,
-                    requestEntity,
+                    request,
                     String.class
             );
 
+            if (response.getStatusCode() != HttpStatus.OK) {
+                throw new AuthFailureHandler(ErrorCode.KAKAO_AUTH_FAILED);
+            }
+
             log.info("[INFO] 카카오 프로필 응답: {}", response.getBody());
             return objectMapper.readValue(response.getBody(), KaKaoResponse.KakaoProfile.class);
+
         } catch (JsonProcessingException e) {
             log.error("[🚨ERROR🚨] 카카오 프로필 파싱 오류: {}", e.getMessage());
             throw new AuthFailureHandler(ErrorCode.KAKAO_JSON_PARSE_ERROR);

--- a/src/main/java/com/mumuk/global/security/oauth/util/NaverUtil.java
+++ b/src/main/java/com/mumuk/global/security/oauth/util/NaverUtil.java
@@ -23,101 +23,45 @@ import java.util.Set;
 public class NaverUtil {
 
     private final ObjectMapper objectMapper;
-    private final StateUtil stateUtil;
 
-
-    @Value("${naver.login.client-id}")
-    private String clientId;
-    @Value("${naver.login.secret-key}")
-    private String clientSecret;
-
-
-    public NaverUtil(ObjectMapper objectMapper, StateUtil stateUtil) {
+    public NaverUtil(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
-        this.stateUtil = stateUtil;
     }
-
-    /**
-     *  인가 코드를 이용해 네이버 서버로부터 OAuth 토큰 반환 받음.
-     *  추후 OAuth Token 을 이용해, 네이버 서버로부터 사용자 정보 반환 => DB 저장 및 자체 인증/인가 로직
-     */
-    public NaverResponse.OAuthToken requestToken(String accessCode, String state) {
-
-        if (!stateUtil.isValidUUID(state)) {
-            log.error("[🚨ERROR🚨] 유효하지 않은 state 값 (UUID 아님): {}", state);
-            throw new AuthFailureHandler(ErrorCode.SOCIAL_LOGIN_INVALID_STATE);
-        }
-
-        // 요청 헤더 및 파라미터 구성
-        RestTemplate restTemplate = new RestTemplate();
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("client_secret",clientSecret);
-        params.add("code", accessCode);
-        params.add("state",state);
-
-        HttpEntity<MultiValueMap<String, String>> naverTokenRequest = new HttpEntity<>(params, headers);
-
-        try {
-            // 네이버 토큰 엔드포인트에 POST 요청
-            ResponseEntity<String> response = restTemplate.exchange(
-                    "https://nid.naver.com/oauth2.0/token",
-                    HttpMethod.POST,
-                    naverTokenRequest,
-                    String.class
-            );
-
-            log.info("[RESPONSE] 네이버 API 응답: {}", response.getBody());
-
-            if (response.getStatusCode() != HttpStatus.OK) {
-                throw new AuthFailureHandler(ErrorCode.NAVER_AUTH_FAILED);
-            }
-
-            // 정상 응답일 경우, 네이버 서버의 JSON 응답을 객체 형태로 역직렬화하여 반환
-            return objectMapper.readValue(response.getBody(), NaverResponse.OAuthToken.class);
-
-        } catch (HttpClientErrorException.Unauthorized e) {
-            log.error("[🚨ERROR🚨] 유효하지 않은 네이버 인증 코드 (401 Unauthorized)");
-            throw new AuthFailureHandler(ErrorCode.NAVER_INVALID_GRANT);
-        } catch (JsonProcessingException e) {
-            log.error("[🚨ERROR🚨] 네이버 응답 JSON 파싱 오류: {}", e.getMessage());
-            throw new AuthFailureHandler(ErrorCode.NAVER_JSON_PARSE_ERROR);
-        } catch (Exception e) {
-            log.error("[🚨ERROR🚨] 네이버 API 호출 중 오류 발생: {}", e.getMessage());
-            throw new AuthFailureHandler(ErrorCode.NAVER_API_ERROR);
-        }
-    }
-
 
     /**
      *  access token 을 사용해 네이버 사용자 정보 요청
      */
-    public NaverResponse.NaverProfile requestProfile(NaverResponse.OAuthToken oAuthToken) {
+    public NaverResponse.NaverProfile requestProfileWithAccessToken(String accessToken) {
 
-        if (oAuthToken == null || oAuthToken.getAccess_token() == null) {
+        if (accessToken == null || accessToken.isBlank()) {
+            log.error("[🚨ERROR🚨] 네이버 Access Token 누락 또는 공백");
             throw new AuthFailureHandler(ErrorCode.NAVER_AUTH_FAILED);
         }
 
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + accessToken);
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-        headers.add("Authorization", "Bearer " + oAuthToken.getAccess_token());
-        HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
 
         try {
             ResponseEntity<String> response = restTemplate.exchange(
                     "https://openapi.naver.com/v1/nid/me",
                     HttpMethod.GET,
-                    requestEntity,
+                    request,
                     String.class
             );
 
             log.info("[INFO] 네이버 프로필 응답: {}", response.getBody());
+
+            if (!response.getStatusCode().is2xxSuccessful()) {
+                log.error("[🚨ERROR🚨] 네이버 프로필 응답 코드: {}", response.getStatusCode());
+                throw new AuthFailureHandler(ErrorCode.NAVER_AUTH_FAILED);
+            }
+
             return objectMapper.readValue(response.getBody(), NaverResponse.NaverProfile.class);
+
         } catch (JsonProcessingException e) {
             log.error("[🚨ERROR🚨] 네이버 프로필 파싱 오류: {}", e.getMessage());
             throw new AuthFailureHandler(ErrorCode.NAVER_JSON_PARSE_ERROR);

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -28,7 +28,4 @@ naver:
     redirect-uri: ${NAVER_PROD_REDIRECT_URI}
 
 kakao:
-  native-app-key: ${KAKAO_NATIVE_APP_KEY}
   redirect-uri: ${KAKAO_PROD_REDIRECT_URI}
-  token-uri: https://kauth.kakao.com/oauth/token
-  user-info-uri: https://kapi.kakao.com/v2/user/me

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,10 +35,7 @@ app:
   env: local
 
 kakao:
-  native-app-key: ${KAKAO_SECRET_KEY}
   redirect-uri: http://localhost:8080/login/oauth2/code/kakao    # 인가 코드
-  token-uri: https://kauth.kakao.com/oauth/token      # 토큰 발급 요청
-  user-info-uri: https://kapi.kakao.com/v2/user/me    # 유저 정보 조회
 
 naver:
   login:


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #112 

## 🔑 주요 내용

- SDK 요청에 따라 OAuth 서버로의 AccessToken 을 받아서 인증 플로우가 이어지도록 리팩토링 하였습니다. 


## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!