### PR TITLE
[REFACTOR] 재료 수정 api 유통기한과 알림설정 수정

### DIFF
--- a/src/main/java/com/mumuk/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/mumuk/domain/ingredient/controller/IngredientController.java
@@ -43,7 +43,7 @@ public class IngredientController {
 
 
     @Operation(summary = "재료의 유통기한 수정", description = "등록하신 재료의 유통기한을 수정합니다.")
-    @PutMapping("/{ingredientId}/update/expireDate")
+    @PutMapping("/{ingredientId}/expireDate")
     public Response<String> updateIngredient(
             @PathVariable Long ingredientId,
             @Valid @RequestBody IngredientRequest.UpdateExpireDateReq req,
@@ -55,7 +55,7 @@ public class IngredientController {
     }
 
     @Operation(summary = "재료의 알림설정 수정", description = "등록하신 재료의 알림설정기간을 수정합니다.")
-    @PutMapping("/{ingredientId}/update/dday-Setting")
+    @PutMapping("/{ingredientId}/dday-Setting")
     public Response<String> updateIngredient(
             @PathVariable Long ingredientId,
             @Valid @RequestBody IngredientRequest.UpdateDdaySettingReq req,

--- a/src/main/java/com/mumuk/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/mumuk/domain/ingredient/controller/IngredientController.java
@@ -42,17 +42,30 @@ public class IngredientController {
     }
 
 
-    @Operation(summary = "재료 수정", description = "등록하신 재료의 상세정보를 수정합니다.")
-    @PatchMapping("/{ingredientId}/update")
+    @Operation(summary = "재료의 유통기한 수정", description = "등록하신 재료의 유통기한을 수정합니다.")
+    @PatchMapping("/{ingredientId}/updateExpireDate")
     public Response<String> updateIngredient(
             @PathVariable Long ingredientId,
-            @Valid @RequestBody IngredientRequest.UpdateReq req,
+            @Valid @RequestBody IngredientRequest.UpdateExpireDateReq req,
             @AuthUser Long userId) {
 
 
-        ingredientService.updateIngredient(ingredientId, req, userId);
+        ingredientService.updateIngredientExpireDate(ingredientId, req, userId);
         return Response.ok(ResultCode.INGREDIENT_UPDATE_OK, "재료 수정 완료");
     }
+
+    @Operation(summary = "재료의 알림설정 수정", description = "등록하신 재료의 알림설정기간을 수정합니다.")
+    @PatchMapping("/{ingredientId}/updateDdaySetting")
+    public Response<String> updateIngredient(
+            @PathVariable Long ingredientId,
+            @Valid @RequestBody IngredientRequest.UpdateDdaySettingReq req,
+            @AuthUser Long userId) {
+
+
+        ingredientService.updateIngredientDdaySetting(ingredientId, req, userId);
+        return Response.ok(ResultCode.INGREDIENT_UPDATE_OK, "재료 수정 완료");
+    }
+
 
     @Operation(summary = "재료 삭제", description = "해당 재료를 삭제합니다.")
     @DeleteMapping("/{ingredientId}/delete")

--- a/src/main/java/com/mumuk/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/mumuk/domain/ingredient/controller/IngredientController.java
@@ -43,7 +43,7 @@ public class IngredientController {
 
 
     @Operation(summary = "재료의 유통기한 수정", description = "등록하신 재료의 유통기한을 수정합니다.")
-    @PutMapping("/{ingredientId}/expireDate")
+    @PutMapping("/{ingredientId}/expiredate")
     public Response<String> updateIngredient(
             @PathVariable Long ingredientId,
             @Valid @RequestBody IngredientRequest.UpdateExpireDateReq req,
@@ -55,7 +55,7 @@ public class IngredientController {
     }
 
     @Operation(summary = "재료의 알림설정 수정", description = "등록하신 재료의 알림설정기간을 수정합니다.")
-    @PutMapping("/{ingredientId}/dday-Setting")
+    @PutMapping("/{ingredientId}/dday-setting")
     public Response<String> updateIngredient(
             @PathVariable Long ingredientId,
             @Valid @RequestBody IngredientRequest.UpdateDdaySettingReq req,
@@ -76,7 +76,7 @@ public class IngredientController {
     }
 
     @Operation(summary = "유통기한 관리", description = "유통기한이 임박한 재료를 조회합니다.")
-    @GetMapping("/expireDateManege")
+    @GetMapping("/expiredatemanege")
     public Response<List<IngredientResponse.ExpireDateManegeRes>> getExpireDateManegeIngredient (@AuthUser Long userId){
 
         List<IngredientResponse.ExpireDateManegeRes> ingredients = ingredientService.getCloseExpireDateIngredients(userId);

--- a/src/main/java/com/mumuk/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/mumuk/domain/ingredient/controller/IngredientController.java
@@ -43,7 +43,7 @@ public class IngredientController {
 
 
     @Operation(summary = "재료의 유통기한 수정", description = "등록하신 재료의 유통기한을 수정합니다.")
-    @PatchMapping("/{ingredientId}/updateExpireDate")
+    @PutMapping("/{ingredientId}/update/expireDate")
     public Response<String> updateIngredient(
             @PathVariable Long ingredientId,
             @Valid @RequestBody IngredientRequest.UpdateExpireDateReq req,
@@ -55,7 +55,7 @@ public class IngredientController {
     }
 
     @Operation(summary = "재료의 알림설정 수정", description = "등록하신 재료의 알림설정기간을 수정합니다.")
-    @PatchMapping("/{ingredientId}/updateDdaySetting")
+    @PutMapping("/{ingredientId}/update/dday-Setting")
     public Response<String> updateIngredient(
             @PathVariable Long ingredientId,
             @Valid @RequestBody IngredientRequest.UpdateDdaySettingReq req,

--- a/src/main/java/com/mumuk/domain/ingredient/dto/request/IngredientRequest.java
+++ b/src/main/java/com/mumuk/domain/ingredient/dto/request/IngredientRequest.java
@@ -29,14 +29,17 @@ public class IngredientRequest {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class UpdateReq {
-
-        @NotNull
-        private String name;
+    public static class UpdateExpireDateReq {
 
         @NotNull
         @JsonFormat(pattern = "yyyy-MM-dd")
         private LocalDate expireDate;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateDdaySettingReq{
 
         @NotNull
         private List<DdayFcmSetting> daySetting;

--- a/src/main/java/com/mumuk/domain/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/mumuk/domain/ingredient/repository/IngredientRepository.java
@@ -7,8 +7,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     List<Ingredient> findAllByUser(User user);
     List<Ingredient> findByUserAndExpireDateBetweenOrderByExpireDateAsc(User user, LocalDate start, LocalDate end);
+    Optional<Ingredient> findByIdAndUser_Id(Long id, Long userId);
 }

--- a/src/main/java/com/mumuk/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/mumuk/domain/ingredient/service/IngredientService.java
@@ -9,7 +9,8 @@ import java.util.List;
 public interface IngredientService {
     void registerIngredient(IngredientRequest.RegisterReq req, Long userId);
     List<IngredientResponse.RetrieveRes> getAllIngredient(Long userId);
-    void updateIngredient(Long ingredientId, IngredientRequest.UpdateReq req, Long userId);
+    void updateIngredientExpireDate(Long ingredientId, IngredientRequest.UpdateExpireDateReq req, Long userId);
+    void updateIngredientDdaySetting(Long ingredientId, IngredientRequest.UpdateDdaySettingReq req, Long userId);
     void deleteIngredient(Long ingredientId, Long userId);
     List<IngredientResponse.ExpireDateManegeRes> getCloseExpireDateIngredients(Long userId);
 

--- a/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
@@ -90,7 +90,7 @@ public enum ErrorCode implements BaseCode {
     INVALID_EXPIREDATE(HttpStatus.BAD_REQUEST, "INGREDIENT_400", "유통기한이 유효하지 않습니다."),
     INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "INGREDIENT_404", "해당 재료가 존재하지 않습니다."),
     USER_NOT_EQUAL(HttpStatus.BAD_REQUEST, "INGREDIENT_403", "해당 사용자의 재료가 아닙니다."),
-
+    INVALID_D_DAY_SETTING(HttpStatus.BAD_REQUEST, "INGREDIENT_400", "올바른 알림설정이 아닙니다."),
 
     //HealthManagement Error
     ALLERGY_NOT_FOUND(HttpStatus.BAD_REQUEST,"ALLERGY_404", "해당 알러지 타입은 존재하지 않습니다,"),


### PR DESCRIPTION
-재료 수정 api 에서 유통기한 수정과 알림설정 수정을 분리하는 작업입니다.

## 🎋 이슈 및 작업중인 브랜치

-  #116 

## 🔑 주요 내용

--재료 수정시에 유통기한을 수정하는 api 와 알림기간을 설정하는 api 를 분리하였습니다.
-재료 수정시 파라미터로 재료 id 를 받고 json 형태로 유통기한 api는 유통기한만 알림설정 api 는 알림설정만 받습니다.
-수정시 이름은 수정하지 않습니다.
<img width="1390" height="780" alt="스크린샷 2025-08-09 오후 5 29 04" src="https://github.com/user-attachments/assets/494f3fcf-d21d-4beb-9feb-c79776e43a54" />
<img width="1390" height="780" alt="스크린샷 2025-08-09 오후 5 29 26" src="https://github.com/user-attachments/assets/209ae7d7-63dd-49f4-955e-90219c8a0624" />
<img width="1390" height="145" alt="스크린샷 2025-08-09 오후 5 29 38" src="https://github.com/user-attachments/assets/06da6b4b-2c0b-43a8-b712-8ef5e3671ada" />



## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 식재료의 유통기한만 별도로 수정하는 전용 엔드포인트가 추가되었습니다.
  * 식재료의 알림(D-day) 설정만 별도로 수정하는 전용 엔드포인트가 추가되었습니다.

* **버그 수정 / 개선**
  * 단일 수정 기능을 유통기한/알림 설정으로 분리해 안정성과 명확성이 향상되었습니다.
  * 알림 설정에 대한 유효성 검사 및 오류 처리가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->