### PR TITLE
[SETTING] 부하 테스트 환경에 Grafana 추가

### DIFF
--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -12,5 +12,3 @@ services:
 
 networks:
   monitoring:
-
-# docker run --rm -v "$PWD/k6:/scripts" grafana/k6 run /scripts/스크립트 파일명

--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -6,7 +6,6 @@ services:
     container_name: k6
     volumes:
       - ./k6:/scripts
-    entrypoint: [ "k6", "run", "/scripts/test.js" ]
     networks:
       - monitoring
 

--- a/docker-compose.k6.yml
+++ b/docker-compose.k6.yml
@@ -1,11 +1,37 @@
 version: '3'
 
+# docker compose up -d influxdb grafana
 services:
+  influxdb:
+    image: influxdb:1.8
+    container_name: influxdb
+    environment:
+      - INFLUXDB_DB=k6
+    volumes:
+      - ./influxdb-data:/var/lib/influxdb
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    depends_on:
+      - influxdb
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=1234
+    networks:
+      - monitoring
+
   k6:
     image: grafana/k6
     container_name: k6
     volumes:
-      - ./k6:/scripts
+      - ./k6:/k6
     networks:
       - monitoring
 

--- a/grafana/provisioning/dashboards/dashboards.yml
+++ b/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: 'k6'
+    orgId: 1
+    folder: 'k6'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/grafana/provisioning/dashboards/k6-influxdb.json
+++ b/grafana/provisioning/dashboards/k6-influxdb.json
@@ -1,0 +1,79 @@
+{
+  "title": "k6 InfluxDB Overview",
+  "schemaVersion": 38,
+  "version": 2,
+  "refresh": "5s",
+  "time": { "from": "now-15m", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "graph",
+      "title": "RPS (http_reqs / 10s)",
+      "datasource": "InfluxDB-k6",
+      "targets": [
+        {
+          "refId": "A",
+          "rawQuery": true,
+          "resultFormat": "time_series",
+          "query": "SELECT sum(\"value\") FROM \"http_reqs\" WHERE $timeFilter GROUP BY time(10s) fill(null)"
+        }
+      ],
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 },
+      "lines": true
+    },
+    {
+      "id": 2,
+      "type": "graph",
+      "title": "Response Time p95 (http_req_duration)",
+      "datasource": "InfluxDB-k6",
+      "targets": [
+        {
+          "refId": "A",
+          "rawQuery": true,
+          "resultFormat": "time_series",
+          "query": "SELECT percentile(\"value\",95) FROM \"http_req_duration\" WHERE $timeFilter GROUP BY time(10s) fill(null)"
+        }
+      ],
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 },
+      "lines": true
+    },
+    {
+      "id": 3,
+      "type": "graph",
+      "title": "Fail Rate (http_req_failed)",
+      "datasource": "InfluxDB-k6",
+      "targets": [
+        {
+          "refId": "A",
+          "rawQuery": true,
+          "resultFormat": "time_series",
+          "query": "SELECT mean(\"value\") FROM \"http_req_failed\" WHERE $timeFilter GROUP BY time(10s) fill(null)"
+        }
+      ],
+      "gridPos": { "x": 0, "y": 8, "w": 12, "h": 8 },
+      "lines": true
+    },
+    {
+      "id": 4,
+      "type": "graph",
+      "title": "Signup / Login p95 (custom)",
+      "datasource": "InfluxDB-k6",
+      "targets": [
+        {
+          "refId": "A",
+          "rawQuery": true,
+          "resultFormat": "time_series",
+          "query": "SELECT percentile(\"value\",95) FROM \"signup_duration\" WHERE $timeFilter GROUP BY time(10s) fill(null)"
+        },
+        {
+          "refId": "B",
+          "rawQuery": true,
+          "resultFormat": "time_series",
+          "query": "SELECT percentile(\"value\",95) FROM \"login_duration\" WHERE $timeFilter GROUP BY time(10s) fill(null)"
+        }
+      ],
+      "gridPos": { "x": 12, "y": 8, "w": 12, "h": 8 },
+      "lines": true
+    }
+  ]
+}

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: InfluxDB-k6
+    type: influxdb
+    access: proxy
+    isDefault: true
+    url: http://influxdb:8086
+    database: k6


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #120 

## 🔑 주요 내용

K6 로 RPS(초당 요청 횟수) 늘려가며 테스트 중인데, 40이 넘어가니까 시각화하는게 좀 더 좋을 듯하여 추가 구축하였습니다.
docker-compose.k6.yml 에 있는 Grafana 는 운영 환경꺼랑 다른거고 , 개발환경에서 K6와 함께 쓰시면 됩니다.

매번 대시보드 설정하기 귀찮아서 Json 으로 이미 세팅해놨고, 3000 포트 쓰시면 됩니다. 

[사용법] 
```
docker compose -f docker-compose.k6.yml up -d influxdb grafana
docker compose -f docker-compose.k6.yml run --rm k6 \
  run -o influxdb=http://influxdb:8086/k6 {스크립트 경로}
```


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * InfluxDB 및 Grafana 서비스를 추가하여 성능 모니터링 및 시각화 기능을 도입했습니다.
  * Grafana에서 k6 테스트 결과를 실시간으로 확인할 수 있는 대시보드가 제공됩니다.
  * InfluxDB와 Grafana 간 데이터 연동이 자동으로 설정됩니다.

* **기타**
  * k6 서비스의 볼륨 마운트 경로가 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->