### PR TITLE
[FEAT] 인기 레시피 기능 구현

### DIFF
--- a/src/main/java/com/mumuk/domain/search/controller/SearchController.java
+++ b/src/main/java/com/mumuk/domain/search/controller/SearchController.java
@@ -89,10 +89,21 @@ public class SearchController {
         return Response.ok(ResultCode.SEARCH_GET_RECENTSEARCHES_OK, recentSearches);
     }
 
-    @Operation(summary = "인기 검색어 조회")
-    @GetMapping("/trends")
-    public Response<SearchResponse.TrendKeywordListRes> getTrend(){
-        SearchResponse.TrendKeywordListRes trendKeywords=trendSearchService.getTrendKeyword();
-        return Response.ok(ResultCode.SEARCH_GET_TRENDKEYWORDS_OK ,trendKeywords);
+    @Operation(summary = "인기 레시피 검색어 조회",
+            description = "검색 화면에서 사용. user-recipe-controller에서 레시피 상세 조회시, 해당 레시피의 id가 현 시간대의 redis에 저장됨." +
+                    "레시피 검색어 조회시 !이전 시간대!의 인기 레시피가 조회됨  ")
+    @GetMapping("/trends/recipe-title")
+    public Response<SearchResponse.TrendRecipeTitleRes> getTrendRecipeTitle(){
+        SearchResponse.TrendRecipeTitleRes trendRecipeTitle=trendSearchService.getTrendRecipeTitleList();
+        return Response.ok(ResultCode.SEARCH_GET_TRENDKEYWORDS_OK ,trendRecipeTitle);
+    }
+
+    @Operation(summary = "인기 레시피 세부 목록 조회",
+            description = "검색 화면에서 사용. user-recipe-controller에서 레시피 상세 조회시, 해당 레시피의 id가 현 시간대의 redis에 저장됨." +
+                    "레시피 검색어 조회시 !이전 시간대!의 인기 레시피가 조회됨")
+    @GetMapping("/trends/recipe-detail")
+    public Response<List<SearchResponse.TrendRecipeDetailRes>> getTrendRecipeDetail(@AuthUser Long userId){
+        List <SearchResponse.TrendRecipeDetailRes> trendRecipeDetail=trendSearchService.getTrendRecipeDetailList(userId);
+        return Response.ok(ResultCode.SEARCH_GET_TRENDKEYWORDS_OK ,trendRecipeDetail);
     }
 }

--- a/src/main/java/com/mumuk/domain/search/controller/SearchController.java
+++ b/src/main/java/com/mumuk/domain/search/controller/SearchController.java
@@ -95,15 +95,15 @@ public class SearchController {
     @GetMapping("/trends/recipe-title")
     public Response<SearchResponse.TrendRecipeTitleRes> getTrendRecipeTitle(){
         SearchResponse.TrendRecipeTitleRes trendRecipeTitle=trendSearchService.getTrendRecipeTitleList();
-        return Response.ok(ResultCode.SEARCH_GET_TRENDKEYWORDS_OK ,trendRecipeTitle);
+        return Response.ok(ResultCode.SEARCH_GET_TRENDRECIPETITLE_OK ,trendRecipeTitle);
     }
 
     @Operation(summary = "인기 레시피 세부 목록 조회",
-            description = "검색 화면에서 사용. user-recipe-controller에서 레시피 상세 조회시, 해당 레시피의 id가 현 시간대의 redis에 저장됨." +
+            description = "홈 화면에서 사용. user-recipe-controller에서 레시피 상세 조회시, 해당 레시피의 id가 현 시간대의 redis에 저장됨." +
                     "레시피 검색어 조회시 !이전 시간대!의 인기 레시피가 조회됨")
     @GetMapping("/trends/recipe-detail")
     public Response<List<SearchResponse.TrendRecipeDetailRes>> getTrendRecipeDetail(@AuthUser Long userId){
         List <SearchResponse.TrendRecipeDetailRes> trendRecipeDetail=trendSearchService.getTrendRecipeDetailList(userId);
-        return Response.ok(ResultCode.SEARCH_GET_TRENDKEYWORDS_OK ,trendRecipeDetail);
+        return Response.ok(ResultCode.SEARCH_GET_TRENDRECIPEDETAIL_OK ,trendRecipeDetail);
     }
 }

--- a/src/main/java/com/mumuk/domain/search/dto/response/SearchResponse.java
+++ b/src/main/java/com/mumuk/domain/search/dto/response/SearchResponse.java
@@ -10,17 +10,25 @@ import java.util.Set;
 public class SearchResponse {
 
     @Getter
-    @AllArgsConstructor
-    public static class TrendKeywordListRes {
-        private final List<String> trendKeywordList;
+    public static class TrendRecipeTitleRes {
+        private final List<String> trendRecipeTitleList;
         private final LocalDateTime localDateTime;
 
-        public TrendKeywordListRes(List<String> trendKeywordList) {
-            this.trendKeywordList = trendKeywordList;
+        public TrendRecipeTitleRes(List<String> trendRecipeTitleList) {
+            this.trendRecipeTitleList = trendRecipeTitleList;
             this.localDateTime = LocalDateTime.now();
         }
     }
 
+    @Getter
+    @AllArgsConstructor
+    public static class TrendRecipeDetailRes {
+        private Long recipeId;
+        private String title;
+        private String imageUrl;
+        private Long calories;
+        private boolean isLiked;
+    }
 
 
 }

--- a/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
@@ -31,7 +31,7 @@ public class SearchServiceImpl implements SearchService {
     }
 
     @Override
-    public List<UserRecipeResponse.RecentRecipeDTO> SearchRecipeList(Long userId, String keyword) {
+    public List<UserRecipeResponse.RecipeSummaryDTO> searchRecipeList(Long userId, String keyword){
 
         if (keyword == null || keyword.isEmpty()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
@@ -52,12 +52,12 @@ public class SearchServiceImpl implements SearchService {
                 .collect(Collectors.toMap(userRecipe -> userRecipe.getRecipe().getId(), userRecipe -> userRecipe));
 
         // RecentRecipeDTO를 반환하는 List 생성
-        List<UserRecipeResponse.RecentRecipeDTO> recipeList = recipes.stream()
+        List<UserRecipeResponse.RecipeSummaryDTO> recipeList = recipes.stream()
                 .map(recipe -> {
                     // 좋아요 여부 입력받기
                     UserRecipe userRecipe = userRecipeMap.get(recipe.getId());
                     boolean isLiked=(userRecipe!=null)&&Boolean.TRUE.equals(userRecipe.getLiked());
-                    return new UserRecipeResponse.RecentRecipeDTO(recipe.getId(),recipe.getTitle(),recipe.getRecipeImage(),isLiked);
+                    return new UserRecipeResponse.RecipeSummaryDTO(recipe.getId(),recipe.getTitle(),recipe.getRecipeImage(),isLiked);
                 }).collect(Collectors.toList());
 
         return recipeList;

--- a/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
@@ -1,6 +1,7 @@
 package com.mumuk.domain.search.service;
 
 import com.mumuk.domain.recipe.dto.response.RecipeResponse;
+import com.mumuk.domain.recipe.entity.Recipe;
 import com.mumuk.domain.recipe.repository.RecipeRepository;
 import com.mumuk.domain.recipe.service.RecipeService;
 import com.mumuk.domain.user.dto.response.UserRecipeResponse;
@@ -32,7 +33,7 @@ public class SearchServiceImpl implements SearchService {
     public List<UserRecipeResponse.RecentRecipeDTO> SearchRecipeList(Long userId, String keyword) {
 
         // 키워드를 바탕으로 결과값 반환
-        List<RecipeResponse.SimpleRes> recipes= recipeRepository.findByTitleContainingIgnoreCase(keyword);
+        List<Recipe> recipes= recipeRepository.findByTitleContainingIgnoreCase(keyword);
 
         // 레시피가 없는 경우 예외 던지기
         if (recipes.isEmpty()) {
@@ -40,7 +41,7 @@ public class SearchServiceImpl implements SearchService {
         }
 
         // 찜하기 여부를 불러오기 위해, 검색결과에서 반환받은 레시피 id를 바탕으로 userRecipe 생성
-        List<UserRecipe> userRecipes =userRecipeRepository.findByUserIdAndRecipeIdIn(userId, recipes.stream().map(RecipeResponse.SimpleRes::getId).collect(Collectors.toList()));
+        List<UserRecipe> userRecipes =userRecipeRepository.findByUserIdAndRecipeIdIn(userId, recipes.stream().map(Recipe::getId).collect(Collectors.toList()));
 
         // dto 생성을 빠르게 하기 위해, recipeId를 키로, userRecipe를 밸류로 하는 map을 생성
         Map<Long, UserRecipe> userRecipeMap = userRecipes.stream()

--- a/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
@@ -1,8 +1,6 @@
 package com.mumuk.domain.search.service;
 
-import com.mumuk.domain.recipe.converter.RecipeConverter;
 import com.mumuk.domain.recipe.dto.response.RecipeResponse;
-import com.mumuk.domain.recipe.entity.Recipe;
 import com.mumuk.domain.recipe.repository.RecipeRepository;
 import com.mumuk.domain.recipe.service.RecipeService;
 import com.mumuk.domain.user.dto.response.UserRecipeResponse;
@@ -22,27 +20,19 @@ public class SearchServiceImpl implements SearchService {
 
     private final RecipeRepository recipeRepository;
     private final UserRecipeRepository userRecipeRepository;
-    private final TrendSearchService trendSearchService;
     private final RecipeService recipeService;
 
-    public SearchServiceImpl(RecipeRepository recipeRepository, UserRecipeRepository userRecipeRepository, TrendSearchService trendSearchService, RecipeService recipeService) {
+    public SearchServiceImpl(RecipeRepository recipeRepository, UserRecipeRepository userRecipeRepository, RecipeService recipeService) {
         this.recipeRepository = recipeRepository;
         this.userRecipeRepository = userRecipeRepository;
-        this.trendSearchService = trendSearchService;
         this.recipeService = recipeService;
     }
 
     @Override
-    public List<UserRecipeResponse.RecipeSummaryDTO> searchRecipeList(Long userId, String keyword) {
+    public List<UserRecipeResponse.RecentRecipeDTO> SearchRecipeList(Long userId, String keyword) {
 
-        // 입력값 null 또는 blank 검사
-        if (keyword == null || keyword.isBlank()) {
-            throw new GlobalException(ErrorCode.INVALID_INPUT);
-        }
-        // 검색어가 유효하면 조회수 증가
-        trendSearchService.increaseKeywordCount(keyword);
         // 키워드를 바탕으로 결과값 반환
-        List<Recipe> recipes = recipeRepository.findByTitleContainingIgnoreCase(keyword);
+        List<RecipeResponse.SimpleRes> recipes= recipeRepository.findByTitleContainingIgnoreCase(keyword);
 
         // 레시피가 없는 경우 예외 던지기
         if (recipes.isEmpty()) {
@@ -50,18 +40,19 @@ public class SearchServiceImpl implements SearchService {
         }
 
         // 찜하기 여부를 불러오기 위해, 검색결과에서 반환받은 레시피 id를 바탕으로 userRecipe 생성
-        List<UserRecipe> userRecipes = userRecipeRepository.findByUserIdAndRecipeIdIn(userId, recipes.stream().map(Recipe::getId).collect(Collectors.toList()));
+        List<UserRecipe> userRecipes =userRecipeRepository.findByUserIdAndRecipeIdIn(userId, recipes.stream().map(RecipeResponse.SimpleRes::getId).collect(Collectors.toList()));
 
         // dto 생성을 빠르게 하기 위해, recipeId를 키로, userRecipe를 밸류로 하는 map을 생성
         Map<Long, UserRecipe> userRecipeMap = userRecipes.stream()
                 .collect(Collectors.toMap(userRecipe -> userRecipe.getRecipe().getId(), userRecipe -> userRecipe));
 
-        // RecipeSummaryDTO를 반환하는 List 생성 (Converter 사용)
-        List<UserRecipeResponse.RecipeSummaryDTO> recipeList = recipes.stream()
+        // RecentRecipeDTO를 반환하는 List 생성
+        List<UserRecipeResponse.RecentRecipeDTO> recipeList = recipes.stream()
                 .map(recipe -> {
+                    // 좋아요 여부 입력받기
                     UserRecipe userRecipe = userRecipeMap.get(recipe.getId());
-                    Boolean liked = (userRecipe != null) ? userRecipe.getLiked() : null;
-                    return RecipeConverter.toRecipeSummaryDTO(recipe, liked);
+                    boolean isLiked=(userRecipe!=null)&&userRecipe.getLiked();
+                    return new UserRecipeResponse.RecentRecipeDTO(recipe.getId(),recipe.getTitle(),recipe.getRecipeImage(),isLiked);
                 }).collect(Collectors.toList());
 
         return recipeList;

--- a/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/SearchServiceImpl.java
@@ -9,6 +9,7 @@ import com.mumuk.domain.user.entity.UserRecipe;
 import com.mumuk.domain.user.repository.UserRecipeRepository;
 import com.mumuk.domain.user.repository.UserRepository;
 import com.mumuk.global.apiPayload.code.ErrorCode;
+import com.mumuk.global.apiPayload.exception.BusinessException;
 import com.mumuk.global.apiPayload.exception.GlobalException;
 import org.springframework.stereotype.Service;
 
@@ -32,12 +33,15 @@ public class SearchServiceImpl implements SearchService {
     @Override
     public List<UserRecipeResponse.RecentRecipeDTO> SearchRecipeList(Long userId, String keyword) {
 
+        if (keyword == null || keyword.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
         // 키워드를 바탕으로 결과값 반환
         List<Recipe> recipes= recipeRepository.findByTitleContainingIgnoreCase(keyword);
 
         // 레시피가 없는 경우 예외 던지기
         if (recipes.isEmpty()) {
-            throw new GlobalException(ErrorCode.SEARCH_RESULT_NOT_FOUND);
+            throw new BusinessException(ErrorCode.SEARCH_RESULT_NOT_FOUND);
         }
 
         // 찜하기 여부를 불러오기 위해, 검색결과에서 반환받은 레시피 id를 바탕으로 userRecipe 생성
@@ -52,7 +56,7 @@ public class SearchServiceImpl implements SearchService {
                 .map(recipe -> {
                     // 좋아요 여부 입력받기
                     UserRecipe userRecipe = userRecipeMap.get(recipe.getId());
-                    boolean isLiked=(userRecipe!=null)&&userRecipe.getLiked();
+                    boolean isLiked=(userRecipe!=null)&&Boolean.TRUE.equals(userRecipe.getLiked());
                     return new UserRecipeResponse.RecentRecipeDTO(recipe.getId(),recipe.getTitle(),recipe.getRecipeImage(),isLiked);
                 }).collect(Collectors.toList());
 

--- a/src/main/java/com/mumuk/domain/search/service/TrendSearchService.java
+++ b/src/main/java/com/mumuk/domain/search/service/TrendSearchService.java
@@ -5,7 +5,14 @@ import com.mumuk.domain.search.dto.response.SearchResponse;
 import java.util.List;
 
 public interface TrendSearchService {
-    public void increaseKeywordCount(String keyword);
-    public SearchResponse.TrendKeywordListRes getTrendKeyword();
+    public void increaseKeywordCount(Long recipeId);
+
+    public void cacheTrendRecipe();
+
+    public  List<Long> getCachedTrendRecipe();
+
+    public SearchResponse.TrendRecipeTitleRes getTrendRecipeTitleList();
+
+    public List<SearchResponse.TrendRecipeDetailRes> getTrendRecipeDetailList(Long userId);
 
 }

--- a/src/main/java/com/mumuk/domain/search/service/TrendSearchServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/TrendSearchServiceImpl.java
@@ -20,9 +20,6 @@ import java.util.stream.Collectors;
 @Service
 public class TrendSearchServiceImpl implements TrendSearchService {
     private static final String CACHEKEY = "trend_recipe";
-
-    // 1시간 단위로 스케줄링!! 스케줄링 어노테이션이 있음
-
     private final String KEY_PREFIX= "trend_keywords";
     private final RedisTemplate<String, String> redisTemplate;
 

--- a/src/main/java/com/mumuk/domain/search/service/TrendSearchServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/search/service/TrendSearchServiceImpl.java
@@ -1,38 +1,125 @@
 package com.mumuk.domain.search.service;
 
+import com.mumuk.domain.recipe.entity.Recipe;
+import com.mumuk.domain.recipe.repository.RecipeRepository;
 import com.mumuk.domain.search.dto.response.SearchResponse;
+import com.mumuk.domain.user.entity.UserRecipe;
+import com.mumuk.domain.user.repository.UserRecipeRepository;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 
 @Service
 public class TrendSearchServiceImpl implements TrendSearchService {
+    private static final String CACHEKEY = "trend_recipe";
 
     // 1시간 단위로 스케줄링!! 스케줄링 어노테이션이 있음
 
-    private final String KEY= "trend_keywords";
+    private final String KEY_PREFIX= "trend_keywords";
     private final RedisTemplate<String, String> redisTemplate;
 
-    public TrendSearchServiceImpl(RedisTemplate<String, String> redisTemplate) {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHH");
+    private final RecipeRepository recipeRepository;
+    private final UserRecipeRepository userRecipeRepository;
+
+
+    public TrendSearchServiceImpl(RedisTemplate<String, String> redisTemplate, RecipeRepository recipeRepository, UserRecipeRepository userRecipeRepository) {
         this.redisTemplate = redisTemplate;
+        this.recipeRepository = recipeRepository;
+        this.userRecipeRepository = userRecipeRepository;
     }
 
     @Override
-    public void increaseKeywordCount(String keyword) {
-        redisTemplate.opsForZSet().incrementScore(KEY,keyword,1);
+    // 검색시 카운트 증가
+    public void increaseKeywordCount(Long recipeId) {
+
+        // ex) 2025080723 -> 2025년 8월 7일 23시~ 24시 사이에 검색된 레시피를 집계하기 위한 key 생성
+        String KEY=KEY_PREFIX+ LocalDateTime.now().format(formatter);
+
+        redisTemplate.opsForZSet().incrementScore(KEY,String.valueOf(recipeId),1);
+
+        redisTemplate.expire(KEY, 2, TimeUnit.HOURS);
     }
 
     @Override
     @Scheduled(cron = "0 0 * * * *")
-    public SearchResponse.TrendKeywordListRes getTrendKeyword() {
-        Set<String> trendKeywordSet = redisTemplate.opsForZSet().reverseRange(KEY,0,9);
-        // 순서 보장 위해 리스트로 한 번 변환
-        List<String> trendKeywordList = new ArrayList<>(trendKeywordSet);
+    // 1시간에 한 번씩 zset에 저장된 검색어 순위들을 불러옴
+    // 스케쥴링을 통해 return한 값들은 별다른 처리가 없다면 버려지기 떄문에, 순위측정을 따로 분리
+    public void cacheTrendRecipe() {
+        // 현재 시간이 23시일 때, 22시~23시 사이예 집계된 레피시를 보여주기 위한 KEY를 생성
+        String KEY=KEY_PREFIX+ LocalDateTime.now().minusHours(1).format(formatter);
+        Set<String> trendRecipeIdSet = redisTemplate.opsForZSet().reverseRange(KEY,0,9);
 
-        return new SearchResponse.TrendKeywordListRes(trendKeywordList);
+        if (trendRecipeIdSet != null && !trendRecipeIdSet.isEmpty()) {
+            redisTemplate.delete(CACHEKEY);
+            redisTemplate.opsForList().rightPushAll(CACHEKEY,new ArrayList<>(trendRecipeIdSet));
+        }
+    }
+
+    @Override
+    public List<Long> getCachedTrendRecipe() {
+        List<String> recipeIdList= redisTemplate.opsForList().range(CACHEKEY,0,9);
+
+        if (recipeIdList == null){
+            return Collections.emptyList();
+        }
+
+        return recipeIdList.stream().map(Long::valueOf).toList();
+    }
+
+    @Override
+    // 레시피 이름만 반환
+    public SearchResponse.TrendRecipeTitleRes getTrendRecipeTitleList() {
+
+        // 캐시된 리스트를 불러옴
+        List<Long> recipeIdList = getCachedTrendRecipe();
+
+        Map<Long, Recipe>  recipeMap= recipeRepository.findAllById(recipeIdList).stream()
+                .collect(Collectors.toMap(Recipe::getId, Function.identity()));
+
+        List<String> trendRecipeTitleList=recipeIdList.stream()
+                .map(id ->recipeMap.get(id).getTitle())
+                .toList();
+
+        return new SearchResponse.TrendRecipeTitleRes(trendRecipeTitleList);
+    }
+
+    @Override
+    // 레시피 정보까지 반환
+    public List<SearchResponse.TrendRecipeDetailRes> getTrendRecipeDetailList(Long userId) {
+
+        List<Long> recipeIdList = getCachedTrendRecipe();
+
+        Map<Long,Recipe> recipeMap = recipeRepository.findAllById(recipeIdList).stream()
+                .collect(Collectors.toMap(Recipe::getId, Function.identity()));
+
+        Map<Long, UserRecipe> userRecipeMap = userRecipeRepository.findByUserIdAndRecipeIdIn(userId,recipeIdList)
+                .stream()
+                .collect(Collectors.toMap(userRecipe -> userRecipe.getRecipe().getId(), Function.identity()));
+
+        List<SearchResponse.TrendRecipeDetailRes> result= recipeIdList.stream()
+                .map(id->{
+                    Recipe recipe = recipeMap.get(id);
+                    boolean isLiked=userRecipeMap.containsKey(id)&&userRecipeMap.get(id).getLiked();
+
+                    return new SearchResponse.TrendRecipeDetailRes(
+                            recipe.getId(),
+                            recipe.getTitle(),
+                            recipe.getRecipeImage(),
+                            recipe.getCalories(),
+                            isLiked
+                    );
+                }).toList();
+
+        return result;
+
     }
 }

--- a/src/main/java/com/mumuk/domain/user/controller/UserRecipeController.java
+++ b/src/main/java/com/mumuk/domain/user/controller/UserRecipeController.java
@@ -2,6 +2,7 @@ package com.mumuk.domain.user.controller;
 
 
 
+import com.mumuk.domain.search.service.TrendSearchService;
 import com.mumuk.domain.user.dto.request.UserRecipeRequest;
 import com.mumuk.domain.user.dto.response.UserRecipeResponse;
 
@@ -22,11 +23,12 @@ import org.springframework.web.bind.annotation.*;
 public class UserRecipeController {
 
     private final UserRecipeService userRecipeService;
+    private final TrendSearchService trendSearchService;
 
-
-    public UserRecipeController(UserRecipeService userRecipeService) {
+    public UserRecipeController(UserRecipeService userRecipeService, TrendSearchService trendSearchService) {
 
         this.userRecipeService = userRecipeService;
+        this.trendSearchService = trendSearchService;
     }
 
 
@@ -34,6 +36,7 @@ public class UserRecipeController {
     @GetMapping("/{recipeId}")
     public Response<UserRecipeResponse.UserRecipeRes> getUserRecipe(@AuthUser Long userId, @PathVariable Long recipeId) {
         UserRecipeResponse.UserRecipeRes response = userRecipeService.getUserRecipeDetail(userId,recipeId);
+        trendSearchService.increaseKeywordCount(recipeId);
         return Response.ok(ResultCode.USER_RECIPE_OK, response);
     }
 

--- a/src/main/java/com/mumuk/global/apiPayload/code/ResultCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ResultCode.java
@@ -57,7 +57,8 @@ public enum ResultCode implements BaseCode {
     SEARCH_SAVE_RECENTSEARCHES_OK(HttpStatus.CREATED,"SEARCH_201", "최근 검색어 저장 성공"),
     SEARCH_DELETE_RECENTSEARCHES_OK(HttpStatus.NO_CONTENT,"SEARCH_204", "최근 검색어 삭제 성공"),
     SEARCH_GET_RECENTSEARCHES_OK(HttpStatus.OK,"SEARCH_200", "최근 검색어 조회 성공"),
-    SEARCH_GET_TRENDKEYWORDS_OK(HttpStatus.OK, "SEARCH_400", "인기 검색어 조회 성공"),
+    SEARCH_GET_TRENDRECIPETITLE_OK(HttpStatus.OK, "SEARCH_400", "인기 레시피 제목 조회 성공"),
+    SEARCH_GET_TRENDRECIPEDETAIL_OK(HttpStatus.OK, "SEARCH_400", "인기 레시피 상세 조회 성공"),
     SEARCH_GET_RECOMMENDED_KEYWORDS_OK(HttpStatus.OK,"SEARCH_400","추천 검색어 조회 성공"),
 
     //HealthManagement Success

--- a/src/main/java/com/mumuk/global/config/RedisAutocompleteInitializer.java
+++ b/src/main/java/com/mumuk/global/config/RedisAutocompleteInitializer.java
@@ -29,7 +29,7 @@ public class RedisAutocompleteInitializer implements CommandLineRunner {
                 redisTemplate.opsForZSet().add(ZSET_KEY, recipe.getTitle(), 0);
             }
         } catch (Exception e) {
-            log.error(String.valueOf(e));
+            log.error("레디스 초기 데이터 구성 실패",e);
         }
 
     }

--- a/src/main/java/com/mumuk/global/config/RedisAutocompleteInitializer.java
+++ b/src/main/java/com/mumuk/global/config/RedisAutocompleteInitializer.java
@@ -23,15 +23,13 @@ public class RedisAutocompleteInitializer implements CommandLineRunner {
     public void run(String... args) throws Exception {
 
         try {
-            log.info("레디스 데이터 초기화 시작");
             List<Recipe> allRecipes = recipeRepository.findAll();
 
             for (Recipe recipe : allRecipes) {
                 redisTemplate.opsForZSet().add(ZSET_KEY, recipe.getTitle(), 0);
             }
-            log.info("레디스 데이터 초기화 성공");
         } catch (Exception e) {
-            log.error("레디스 데이터 초기화 실패", e);
+            log.error(String.valueOf(e));
         }
 
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
   data:
     redis:
       host: localhost
-      port: 6380
+      port: 6379
 
 
 jwt:


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #110 

## 🔑 주요 내용

- 인기 검색어 기능에 대해서, "사용자가 검색한 단어"에 대해 순위를 매기는 것에서 "사용자가 조회한 레시피"에 순위를 매겨 표시하는 기능으로 바꿨습니다.
- 이에 따라, redis에 저장되는 값을 "사용자가 검색한 단어" 대신 "사용자가 조회한 레시피의 id" 로 변경했습니다.
- 스케쥴링을 통해서 주기적으로 메서드를 수행하더라도 반환된 값들은 사용되지 못 하고 버려집니다. 따라서 스케쥴링 대상을 바꿔 1시간마다 레디스에 저장된 인기 검색어를 1위부터 10위까지 불러오도록 했고, 이를 redis에 trend_recipe라는 키로 저장해 값을 캐싱했습니다.  
- 인기 검색어 기능은 검색 화면과 홈 화면에서 사용, 각 화면에서 필요한 정보들을 반환하는 api 구현했습니다. 
- 검색한 레시피 조회수 증가는 가은님의 레시피 상세조회 api와 연결해두었습니다. 사용자가 레시피 조회시, redis에 저장된 레시피의 조회수가 증가합니다.
- 레시피 조회수 집계는 각 시간별로 진행됩니다. 13시~14시 사이에 검색된 레시피들은 14시 이후에 trend recipe에 올라가 인기 검색어에 노출됩니다. 

<img width="2728" height="1637" alt="스크린샷 2025-08-10 143627" src="https://github.com/user-attachments/assets/d2eb54e2-d25d-4150-8975-65873b7813e4" />

홈 화면에서 사용될 인기레시피 상세목록입니다.

<img width="2083" height="1565" alt="스크린샷 2025-08-10 143606" src="https://github.com/user-attachments/assets/539554f0-8bcb-40f1-b84f-fd6f6743da3d" />

검색 화면에서 사용될 인기 레시피 제목 목록입니다.

<img width="644" height="149" alt="image" src="https://github.com/user-attachments/assets/6ee3ac93-6b2e-4646-9f95-390cef0d34b3" />

redis에 키는 다음과 같이 저장됩니다.

trend_keywords + yyyyMMddHH 형태로 키가 저장되며, 현재 시각이 10시 22분일 경우
trend_keywords2025081022 -> 인기 레시피 집계를 위한 키
trend_keywords2025081021 -> 집계된 인기 레시피를 보여주기 위한 키

현재 시각에서부터 1시간 이전의 키는 집계된 인기 레시피를 보여주기 위한 키로, 매 시각마다 trend_recipe 키에 캐싱되어 사용됩니다.


## Check List

- [X] **Reviewers** 등록을 하였나요?
- [X] **Assignees** 등록을 하였나요?
- [X] **라벨(Label)** 등록을 하였나요?
- [X] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 인기 검색어 대신 인기 레시피 제목 및 상세 정보를 제공하는 새로운 트렌드 레시피 API가 추가되었습니다.
  * 트렌드 레시피 상세 정보 조회 시, 사용자별 '좋아요' 여부 등 개인화된 정보를 함께 제공합니다.

* **버그 수정**
  * Redis 서버 포트가 6380에서 6379로 변경되어 연결 안정성이 향상되었습니다.

* **기타**
  * 인기 검색어 기반 트렌드 기능이 레시피 기반 트렌드 기능으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->