### PR TITLE
재료 항목에 수량 추가, 수량 수정 기능 추가

### DIFF
--- a/src/main/java/com/mumuk/domain/ingredient/controller/IngredientController.java
+++ b/src/main/java/com/mumuk/domain/ingredient/controller/IngredientController.java
@@ -44,7 +44,7 @@ public class IngredientController {
 
     @Operation(summary = "재료의 유통기한 수정", description = "등록하신 재료의 유통기한을 수정합니다.")
     @PutMapping("/{ingredientId}/expiredate")
-    public Response<String> updateIngredient(
+    public Response<String> updateExpireDate(
             @PathVariable Long ingredientId,
             @Valid @RequestBody IngredientRequest.UpdateExpireDateReq req,
             @AuthUser Long userId) {
@@ -56,13 +56,25 @@ public class IngredientController {
 
     @Operation(summary = "재료의 알림설정 수정", description = "등록하신 재료의 알림설정기간을 수정합니다.")
     @PutMapping("/{ingredientId}/dday-setting")
-    public Response<String> updateIngredient(
+    public Response<String> updateDdaySetting(
             @PathVariable Long ingredientId,
             @Valid @RequestBody IngredientRequest.UpdateDdaySettingReq req,
             @AuthUser Long userId) {
 
 
         ingredientService.updateIngredientDdaySetting(ingredientId, req, userId);
+        return Response.ok(ResultCode.INGREDIENT_UPDATE_OK, "재료 수정 완료");
+    }
+
+    @Operation(summary = "재료의 수량 수정", description = "등록하신 재료의 수량을 수정합니다.")
+    @PutMapping("/{ingredientId}/quantity")
+    public Response<String> updateQuantity(
+            @PathVariable Long ingredientId,
+            @Valid @RequestBody IngredientRequest.UpdateQuantityReq req,
+            @AuthUser Long userId) {
+
+
+        ingredientService.updateIngredientQuantity(ingredientId, req, userId);
         return Response.ok(ResultCode.INGREDIENT_UPDATE_OK, "재료 수정 완료");
     }
 

--- a/src/main/java/com/mumuk/domain/ingredient/converter/IngredientConverter.java
+++ b/src/main/java/com/mumuk/domain/ingredient/converter/IngredientConverter.java
@@ -7,7 +7,6 @@ import com.mumuk.domain.ingredient.entity.Ingredient;
 import com.mumuk.domain.ingredient.entity.IngredientNotification;
 import com.mumuk.domain.user.entity.User;
 import org.springframework.stereotype.Component;
-
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -21,6 +20,7 @@ public class IngredientConverter {
         ingredient.setName(req.getName());
         ingredient.setExpireDate(req.getExpireDate());
         ingredient.setUser(user);
+        ingredient.setQuantity(1); //재료 개수 기본값 1
         ingredient.setDaySettings(
                 List.of(new IngredientNotification(ingredient, DdayFcmSetting.NONE))
         );//기본값 NONE 리스트 설정.업데이트시 새로운 리스트로 Set 하므로 불변리스트로 코드 간략화
@@ -33,7 +33,8 @@ public class IngredientConverter {
                 ingredient.getId(),
                 ingredient.getName(),
                 ingredient.getExpireDate(),
-                ingredient.getCreatedAt());
+                ingredient.getCreatedAt(),
+                ingredient.getQuantity());
 
     }
 

--- a/src/main/java/com/mumuk/domain/ingredient/dto/request/IngredientRequest.java
+++ b/src/main/java/com/mumuk/domain/ingredient/dto/request/IngredientRequest.java
@@ -44,4 +44,12 @@ public class IngredientRequest {
         @NotNull
         private List<DdayFcmSetting> daySetting;
     }
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateQuantityReq{
+
+        @NotNull
+        private Integer quantity;
+    }
 }

--- a/src/main/java/com/mumuk/domain/ingredient/dto/response/IngredientResponse.java
+++ b/src/main/java/com/mumuk/domain/ingredient/dto/response/IngredientResponse.java
@@ -1,5 +1,6 @@
 package com.mumuk.domain.ingredient.dto.response;
 
+import com.mumuk.domain.ingredient.entity.Ingredient;
 import lombok.*;
 
 import java.time.LocalDate;
@@ -14,6 +15,7 @@ public class IngredientResponse {
         private String name;
         private LocalDate expireDate;
         private LocalDateTime createdAt;
+        private Integer quantity;
     }
 
     @Getter

--- a/src/main/java/com/mumuk/domain/ingredient/entity/Ingredient.java
+++ b/src/main/java/com/mumuk/domain/ingredient/entity/Ingredient.java
@@ -21,6 +21,9 @@ public class Ingredient extends BaseEntity {
     @Column(name = "유통기한", nullable = false)
     private LocalDate expireDate;
 
+    @Column(name = "재료수량", nullable = false)
+    private Integer quantity;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -44,6 +47,8 @@ public class Ingredient extends BaseEntity {
         return expireDate;
     }
 
+    public Integer getQuantity() {return quantity;}
+
     public User getUser() {return user;}
 
     public List<IngredientNotification> getDaySettings() {return daySettings;}
@@ -60,6 +65,8 @@ public class Ingredient extends BaseEntity {
     public void setExpireDate(LocalDate expireDate) {
         this.expireDate = expireDate;
     }
+
+    public void setQuantity(Integer quantity) {this.quantity = quantity;}
 
     public void setUser(User user) {this.user = user;}
 

--- a/src/main/java/com/mumuk/domain/ingredient/service/IngredientService.java
+++ b/src/main/java/com/mumuk/domain/ingredient/service/IngredientService.java
@@ -11,6 +11,7 @@ public interface IngredientService {
     List<IngredientResponse.RetrieveRes> getAllIngredient(Long userId);
     void updateIngredientExpireDate(Long ingredientId, IngredientRequest.UpdateExpireDateReq req, Long userId);
     void updateIngredientDdaySetting(Long ingredientId, IngredientRequest.UpdateDdaySettingReq req, Long userId);
+    void updateIngredientQuantity(Long ingredientId, IngredientRequest.UpdateQuantityReq req, Long userId);
     void deleteIngredient(Long ingredientId, Long userId);
     List<IngredientResponse.ExpireDateManegeRes> getCloseExpireDateIngredients(Long userId);
 

--- a/src/main/java/com/mumuk/domain/ingredient/service/IngredientServiceImpl.java
+++ b/src/main/java/com/mumuk/domain/ingredient/service/IngredientServiceImpl.java
@@ -102,6 +102,25 @@ public class IngredientServiceImpl implements IngredientService {
 
     @Transactional
     @Override
+    public void updateIngredientQuantity(Long ingredientId, IngredientRequest.UpdateQuantityReq req, Long userId) {
+
+        Ingredient ingredient = ingredientRepository.findByIdAndUser_Id(ingredientId,userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INGREDIENT_NOT_FOUND));
+
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        //입력한 수량이 0보다 작을경우 예외 발생.
+        if (req.getQuantity() < 0) {
+            throw new BusinessException(ErrorCode.INVALID_QUANTITY);
+        }
+
+
+        ingredient.setQuantity(req.getQuantity());
+        ingredientRepository.save(ingredient);
+    }
+
+    @Transactional
+    @Override
     public void deleteIngredient(Long ingredientId, Long userId) {
 
         User user = userRepository.findById(userId)

--- a/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
+++ b/src/main/java/com/mumuk/global/apiPayload/code/ErrorCode.java
@@ -91,6 +91,9 @@ public enum ErrorCode implements BaseCode {
     INGREDIENT_NOT_FOUND(HttpStatus.NOT_FOUND, "INGREDIENT_404", "해당 재료가 존재하지 않습니다."),
     USER_NOT_EQUAL(HttpStatus.BAD_REQUEST, "INGREDIENT_403", "해당 사용자의 재료가 아닙니다."),
     INVALID_D_DAY_SETTING(HttpStatus.BAD_REQUEST, "INGREDIENT_400", "올바른 알림설정이 아닙니다."),
+    INVALID_QUANTITY(HttpStatus.BAD_REQUEST, "INGREDIENT_400", "올바른 수량이 아닙니다."),
+
+
 
     //HealthManagement Error
     ALLERGY_NOT_FOUND(HttpStatus.BAD_REQUEST,"ALLERGY_404", "해당 알러지 타입은 존재하지 않습니다,"),


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- #130 

## 🔑 주요 내용

- 재료 엔티티에 수량항목을 추가했습니다.
- 수량은 재료 수정에서 수정할수있으며 조회에서 확인할 수 있습니다.
- 재료 등록시 기본값으로 1로 수정됩니다.
<img width="1390" height="804" alt="스크린샷 2025-08-11 오후 6 24 40" src="https://github.com/user-attachments/assets/c0276864-fee2-44a6-966e-78df8b52b20c" />
<img width="1390" height="804" alt="스크린샷 2025-08-11 오후 6 24 46" src="https://github.com/user-attachments/assets/4eced7a6-38d0-4a41-bc93-ebb351dee5f6" />
<img width="1390" height="804" alt="스크린샷 2025-08-11 오후 6 24 52" src="https://github.com/user-attachments/assets/3ffb45af-93a5-4273-90aa-6c9badb6f289" />


## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 재료 수량 관리 추가: 등록 시 기본 수량 1로 저장되며, 재료 조회 응답에 수량 필드가 새로 노출됩니다.
  * 재료 수량 수정 API 추가: 수량을 직접 변경할 수 있고, 음수 값 요청 시 잘못된 수량 오류를 반환합니다.
* Refactor
  * 만료일/디데이 관련 엔드포인트의 메서드 명을 명확화했습니다. 기능, 경로, 응답 구조에는 변화가 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->